### PR TITLE
remove 'servicehost' role

### DIFF
--- a/roles/servicehost/tasks/main.yml
+++ b/roles/servicehost/tasks/main.yml
@@ -1,8 +1,0 @@
-- name: install ansible
-  # note: cached is just useful on the plane
-  pkgng: name=ansible state=present cached=true
-- name: configure root
-  user: name=root
-- name: configure users
-  user: name={{ item }}
-  with_items: admin_users


### PR DESCRIPTION
- it's unused
- our workflow covers what it's supposed to do
