### PR TITLE
Clarify IP space

### DIFF
--- a/docs/network.txt
+++ b/docs/network.txt
@@ -1,9 +1,9 @@
 IP Space
 ========
 
-Public IP space is 140.211.10.128/25, in a single VLAN
+Public IP space is 140.211.10.128/25, in a single VLAN shared with RTEMS.
 
-Shared with RTEMS; buildbot is allocated a /27 out of that
+Buildbot is allocated 140.211.10.224/27 out of that /25.
 
 DNS
 ===


### PR DESCRIPTION
Clarify the IP range Buildbot has. Some of the IPs in the beginning of the /27 appears to be unused. Need to document what machines/jails have what still.
