### PR TITLE
Set up syslog to forward to the syslog server

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -50,3 +50,6 @@ utility_packages:
 
 # The upstream repository from which the service host crontask should pull
 ansible_git_repository: git://github.com/buildbot/buildbot-infra
+
+# syslog server to which all syslog messages should be forwarded
+global_syslog_server: 192.168.80.51

--- a/roles/base/handlers/main.yml
+++ b/roles/base/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload syslogd
+  service:
+    name: syslogd
+    state: reloaded

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -1,5 +1,6 @@
 ---
 - include: packages.yml
 - include: sudo.yml
+- include: syslog.yml
 - include: rootpw.yml
 - include: ansible-pull.yml

--- a/roles/base/tasks/syslog.yml
+++ b/roles/base/tasks/syslog.yml
@@ -1,0 +1,17 @@
+---
+- name: "start syslog"
+  service:
+    name: syslogd
+    enabled: yes
+    state: started
+
+- name: "syslog.conf - add configuration to send to global_syslog_server"
+  tags: syslog
+  lineinfile:
+    line: "*.* @{{ global_syslog_server }}"
+    regexp: "^\\*.\\* @"
+    # insert after the header comment so we're not filtered
+    # by any preceding programs (!) or hosts (+).
+    insertafter: "Consult the syslog.conf.5. manpage."
+    dest: /etc/syslog.conf
+  notify: reload syslogd


### PR DESCRIPTION
This is in the 'base' role since I think both service hosts and jails should run this.
