### PR TITLE
re-order buildbot.net zone items

### DIFF
--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -10,14 +10,14 @@
 @               7200    IN      A       63.245.223.35
 buildbot        7200    IN      CNAME   ds0210.flosoft-servers.net.
 docs            7200    IN      CNAME   ds0210.flosoft-servers.net.
+meetings        43200   IN      CNAME   ds0210.flosoft-servers.net.
+rc              86400   IN      CNAME   ds0210.flosoft-servers.net.
 www             7200    IN      CNAME   buildbot.net.
 xy2dwhhhx5d4    7200    IN      CNAME   gv-d47fzorbndt4i4.dv.googlehosted.com.
-meetings        43200   IN      CNAME   ds0210.flosoft-servers.net.
 mx              86400   IN      A       140.211.10.235
 @               86400   IN      MX      10 mx.buildbot.net.
 lists           86400   IN      A       140.211.10.241
 trac            86400   IN      A       140.211.10.240
-rc              86400   IN      CNAME   ds0210.flosoft-servers.net.
 ftp             86400   IN      A       140.211.10.243
 bot             86400   IN      A       140.211.10.242
 service1        86400   IN      A       140.211.10.230


### PR DESCRIPTION
- this allows to easily see what services are run flosoft server
- no other changes -> no serial bump
