### PR TITLE
point bb.bb.net A record to the right place

### DIFF
--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -1,5 +1,5 @@
 @       86400   IN      SOA     ns1.buildbot.net. hostmaster.buildbot.net. (
-                                        2015010202      ;serial
+                                        2015010501      ;serial
                                         10800           ;refresh
                                         1800            ;retry
                                         604800          ;expire
@@ -10,7 +10,7 @@
 @               7200    IN      NS      ns2.he.net.         ; usa
 @               86400   IN      MX      10 mx.buildbot.net.
 @               7200    IN      A       140.211.10.238
-buildbot        7200    IN      CNAME   ds0210.flosoft-servers.net.
+buildbot        7200    IN      A       140.211.10.239
 meetings        43200   IN      CNAME   ds0210.flosoft-servers.net.
 xy2dwhhhx5d4    7200    IN      CNAME   gv-d47fzorbndt4i4.dv.googlehosted.com.
 mx              86400   IN      A       140.211.10.235


### PR DESCRIPTION
This PR finalises the [task](http://trac.buildbot.net/ticket/2850#comment:15) for moving bb.bb.net off the flosoft machine.