### PR TITLE
add rsync to utility package list

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -45,6 +45,7 @@ mandatory_packages:
 # The original list is based on http://trac.buildbot.net/ticket/3036
 utility_packages:
 - bash
+- rsync
 - screen
 - vim-lite  # we probably do not want to bring all the stuff
 


### PR DESCRIPTION
It is quite useful when a set of packages needs to be moved between machines.