### PR TITLE
Configure sendmail for local mail delivery on all hosts and jails

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -55,6 +55,9 @@ ansible_git_repository: git://github.com/buildbot/buildbot-infra
 # syslog server to which all syslog messages should be forwarded
 global_syslog_server: 192.168.80.51
 
+# Alias for email to root (cronspam, etc.)
+root_email_destination: "sysadmin@buildbot.net"
+
 # This structure refers to `build_slaves` in `secrets.yml`
 slave_master_allocations:
   nine:

--- a/host-service1.yml
+++ b/host-service1.yml
@@ -6,3 +6,4 @@
   sudo: yes
   roles:
   - base-servicehost
+  - sendmail

--- a/host-service2.yml
+++ b/host-service2.yml
@@ -6,3 +6,4 @@
   sudo: yes
   roles:
   - base-servicehost
+  - sendmail

--- a/host-service3.yml
+++ b/host-service3.yml
@@ -6,3 +6,4 @@
   sudo: yes
   roles:
   - base-servicehost
+  - sendmail

--- a/host-vm1.yml
+++ b/host-vm1.yml
@@ -7,6 +7,7 @@
   roles:
   # Restore once jails are moved to service{1,2,3}
   # - base-servicehost
+  - sendmail
   - role: jail
     name: buildbot
     hostname: buildbot.buildbot.net

--- a/jail-bslave1.yml
+++ b/jail-bslave1.yml
@@ -14,6 +14,7 @@
   # to support them something "interesting" needs to be done.
   roles:
   - base
+  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-buildbot.yml
+++ b/jail-buildbot.yml
@@ -12,6 +12,7 @@
 
   roles:
   - base
+  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-docs.yml
+++ b/jail-docs.yml
@@ -13,6 +13,7 @@
 
   roles:
   - base
+  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-nine.yml
+++ b/jail-nine.yml
@@ -12,6 +12,7 @@
 
   roles:
   - base
+  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-ns1.yml
+++ b/jail-ns1.yml
@@ -6,4 +6,5 @@
   sudo: yes
   roles:
   - base
+  - sendmail
   - dns

--- a/jail-www.yml
+++ b/jail-www.yml
@@ -10,6 +10,7 @@
 
   roles:
   - base
+  - sendmail
   - role: packages
     packages:
     - node

--- a/roles/sendmail/handlers/main.yml
+++ b/roles/sendmail/handlers/main.yml
@@ -1,0 +1,5 @@
+---
+- name: reload sendmail
+  service:
+    name: sendmail
+    state: restarted

--- a/roles/sendmail/handlers/main.yml
+++ b/roles/sendmail/handlers/main.yml
@@ -3,3 +3,6 @@
   service:
     name: sendmail
     state: restarted
+
+- name: newaliases
+  command: /usr/bin/newaliases

--- a/roles/sendmail/tasks/main.yml
+++ b/roles/sendmail/tasks/main.yml
@@ -1,0 +1,18 @@
+# these sendmail options allow local mail submission; see #3131
+- name: set sendmail options
+  lineinfile:
+    dest: "/etc/rc.conf"
+    line: "{{item.option}}=\"{{item.value}}\""
+    regexp: "^{{item.option}}=.*"
+    state: present
+  notify: reload sendmail
+  with_items:
+    - {option: "sendmail_submit_enable", value: "NO"}
+    - {option: "sendmail_outbound_enable", value: "YES"}
+    - {option: "sendmail_msp_queue_enable", value: "YES"}
+
+- name: start sendmail
+  service:
+    name: sendmail
+    enabled: true
+    state: running

--- a/roles/sendmail/tasks/main.yml
+++ b/roles/sendmail/tasks/main.yml
@@ -11,6 +11,14 @@
     - {option: "sendmail_outbound_enable", value: "YES"}
     - {option: "sendmail_msp_queue_enable", value: "YES"}
 
+- name: update root mail alias
+  lineinfile:
+    dest: "/etc/mail/aliases"
+    line: "root: {{root_email_destination}}"
+    regexp: "^#?root:"
+    state: present
+  notify: newaliases
+
 - name: start sendmail
   service:
     name: sendmail


### PR DESCRIPTION
This also sets an alias for root.  I've updated this on service2, so we may see incoming cronspam from that host.