### PR TITLE
Manage all jails

### DIFF
--- a/jail-bot.yml
+++ b/jail-bot.yml
@@ -1,0 +1,10 @@
+---
+# TODO: actually manage configuration (#3154)
+- name: configure bot
+  hosts: bot
+  gather_facts: no
+  connection: local
+  sudo: yes
+  roles:
+  - base
+

--- a/jail-ftp.yml
+++ b/jail-ftp.yml
@@ -1,0 +1,10 @@
+---
+# TODO: actually manage configuration (#3044)
+- name: configure ftp
+  hosts: ftp
+  gather_facts: no
+  connection: local
+  sudo: yes
+  roles:
+  - base
+

--- a/jail-lists.yml
+++ b/jail-lists.yml
@@ -1,0 +1,10 @@
+---
+# TODO: actually manage configuration (#3040)
+- name: configure lists
+  hosts: lists
+  gather_facts: no
+  connection: local
+  sudo: yes
+  roles:
+  - base
+

--- a/jail-mx.yml
+++ b/jail-mx.yml
@@ -1,0 +1,9 @@
+---
+# TODO: actually manage configuration (#3046)
+- name: configure mx
+  hosts: mx
+  gather_facts: no
+  connection: local
+  sudo: yes
+  roles:
+  - base

--- a/jail-mysql.yml
+++ b/jail-mysql.yml
@@ -1,0 +1,10 @@
+---
+# TODO: actually manage configuration (#3047)
+- name: configure mysql
+  hosts: mysql
+  gather_facts: no
+  connection: local
+  sudo: yes
+  roles:
+  - base
+

--- a/jail-syslog.yml
+++ b/jail-syslog.yml
@@ -1,0 +1,13 @@
+---
+# TODO: actually manage configuration (#3135)
+- name: configure syslog
+  hosts: syslog
+  gather_facts: no
+  connection: local
+  sudo: yes
+  roles:
+    - role: base
+      # don't add the base configuration for syslog here, as this host
+      # has its own syslog configuration
+      configure_syslog: False
+

--- a/jail-trac.yml
+++ b/jail-trac.yml
@@ -1,0 +1,10 @@
+---
+# TODO: actually manage configuration (#3038)
+- name: configure trac
+  hosts: trac
+  gather_facts: no
+  connection: local
+  sudo: yes
+  roles:
+  - base
+

--- a/local.yml
+++ b/local.yml
@@ -18,18 +18,26 @@
       key: "{{ansible_hostname}}"
     changed_when: False
 
-# Service hosts
+# Service hosts and their jails
 - include: "host-service1.yml"
-- include: "host-service2.yml"
-- include: "host-service3.yml"
-- include: "host-vm1.yml"
+- include: "jail-ns1.yml"
+- include: "jail-mx.yml"
+- include: "jail-syslog.yml"
 
-# Jails
+- include: "host-service2.yml"
+- include: "jail-trac.yml"
+- include: "jail-lists.yml"
+- include: "jail-bot.yml"
+- include: "jail-ftp.yml"
+- include: "jail-nine.yml"
+
+- include: "host-service3.yml"
+- include: "jail-mysql.yml"
+
+- include: "host-vm1.yml"
 - include: "jail-bslave1.yml"
 - include: "jail-buildbot.yml"
 - include: "jail-docs.yml"
-- include: "jail-nine.yml"
-- include: "jail-ns1.yml"
 - include: "jail-www.yml"
 
 # vim:ts=2:sw=2:noai:nosi

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -1,0 +1,5 @@
+---
+# set this to False to skip configuring syslog (on a host with a special syslog
+# configuration)
+configure_syslog: True
+

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -2,4 +2,3 @@
 # set this to False to skip configuring syslog (on a host with a special syslog
 # configuration)
 configure_syslog: True
-

--- a/roles/base/tasks/syslog.yml
+++ b/roles/base/tasks/syslog.yml
@@ -4,6 +4,7 @@
     name: syslogd
     enabled: yes
     state: started
+  when: configure_syslog
 
 - name: "syslog.conf - add configuration to send to global_syslog_server"
   tags: syslog
@@ -15,3 +16,4 @@
     insertafter: "Consult the syslog.conf.5. manpage."
     dest: /etc/syslog.conf
   notify: reload syslogd
+  when: configure_syslog


### PR DESCRIPTION
This adds just the 'base' role for all jails, which at the very least
means that they run Ansible regularly.  It carefully avoids configuring
a syslog loop on the syslog jail.