### PR TITLE
Add a delegated reverse zone for Buildbot's /27

### DIFF
--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -33,10 +33,13 @@
   - localhost-reverse.db
   notify: reload named
 
-- name: install buildbot.net zone
+- name: install master zone files
   template:
-    src: "buildbot.net"
-    dest: "{{ namedb_dir }}/master/buildbot.net"
+    src: "{{ item }}"
+    dest: "{{ namedb_dir }}/master/{{ item }}"
+  with_items:
+    - buildbot.net
+    - 224-255.128-255.10.211.140.in-addr.arpa
   notify: reload named
 
 - name: install BIND configuration files

--- a/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
+++ b/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
@@ -1,0 +1,42 @@
+@       86400   IN      SOA     ns1.buildbot.net. hostmaster.buildbot.net. (
+                                        2015011801      ;serial
+                                        10800           ;refresh
+                                        1800            ;retry
+                                        604800          ;expire
+                                        86400   )       ;minimum
+@               7200    IN      NS      c.ns.buddyns.com.   ; germany
+@               7200    IN      NS      f.ns.buddyns.com.   ; india
+@               7200    IN      NS      ns1.he.net.         ; usa
+@               7200    IN      NS      ns2.he.net.         ; usa
+
+;224
+;225
+;226
+;227
+;228
+;229
+230     86400   IN       PTR     service1.buildbot.net.
+231     86400   IN       PTR     service2.buildbot.net.
+232     86400   IN       PTR     service3.buildbot.net.
+233     86400   IN       PTR     vm1.buildbot.net.
+234     86400   IN       PTR     mac1.buildbot.net.
+235     86400   IN       PTR     mx.buildbot.net.
+236     86400   IN       PTR     ns1.buildbot.net.
+237     86400   IN       PTR     docs.buildbot.net.
+238     86400   IN       PTR     buildbot.net.
+239     86400   IN       PTR     buildbot.buildbot.net.
+240     86400   IN       PTR     trac.buildbot.net.
+241     86400   IN       PTR     lists.buildbot.net.
+242     86400   IN       PTR     bot.buildbot.net.
+243     86400   IN       PTR     ftp.buildbot.net.
+244     86400   IN       PTR     nine.buildbot.net.
+;245
+;246
+;247
+;248
+;249
+;250
+;251
+;252
+;253
+;254

--- a/roles/dns/templates/named.conf.zones
+++ b/roles/dns/templates/named.conf.zones
@@ -20,4 +20,19 @@ zone "buildbot.net" {
     };
 };
 
+zone "224-255.128-255.10.211.140.in-addr.arpa" {
+    type master;
+    file "{{ namedb_dir }}/master/224-255.128-255.10.211.140.in-addr.arpa";
+    allow-transfer {
+        "buildbot.net-upstream";
+    };
+    notify explicit;
+    also-notify {
+        173.244.206.26;     /* a.transfer.buddyns.com */
+        88.198.106.11;      /* b.transfer.buddyns.com */
+        78.46.95.154;       /* c.transfer.buddyns.com */
+        216.218.130.2;      /* ns1.he.net */
+    };
+};
+
 // vim:ft=named


### PR DESCRIPTION
This will require adding
```
224-255 NS c.ns.buddyns.com.
224-255 NS f.ns.buddyns.com.
224-255 NS ns1.he.net.
224-255 NS ns2.he.net.
$GENERATE 224-255 $ CNAME $.224-255
```
to the RTEMS zonefile for `128-255.10.211.140.in-addr.arpa`.  If that's not running BIND, then it looks more like
```
224-255 NS c.ns.buddyns.com.
224-255 NS f.ns.buddyns.com.
224-255 NS ns1.he.net.
224-255 NS ns2.he.net.
224 CNAME 224.224-255
225 CNAME 225.224-255
...
255 CNAME 255.224-255
```
(with the middle part filled in, of course).

This shouldn't require any change in the delegation from OSUOSL.  Note that I haven't set up the slave zones at buddyns and HE yet (I can't until ns1.bb.net is serving the zone).

@verm does this look right to you?