### PR TITLE
Configure sendmail in the 'base' role

### DIFF
--- a/jail-bslave1.yml
+++ b/jail-bslave1.yml
@@ -14,7 +14,6 @@
   # to support them something "interesting" needs to be done.
   roles:
   - base
-  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-buildbot.yml
+++ b/jail-buildbot.yml
@@ -12,7 +12,6 @@
 
   roles:
   - base
-  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-docs.yml
+++ b/jail-docs.yml
@@ -13,7 +13,6 @@
 
   roles:
   - base
-  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-lists.yml
+++ b/jail-lists.yml
@@ -6,5 +6,5 @@
   connection: local
   sudo: yes
   roles:
-  - base
-
+  - role: base
+    configure_sendmail: False

--- a/jail-mx.yml
+++ b/jail-mx.yml
@@ -6,4 +6,5 @@
   connection: local
   sudo: yes
   roles:
-  - base
+  - role: base
+    configure_sendmail: False

--- a/jail-nine.yml
+++ b/jail-nine.yml
@@ -12,7 +12,6 @@
 
   roles:
   - base
-  - sendmail
   - role: user
     user_id: "{{ worker_account }}"
     user_name: Buildbot Worker Account

--- a/jail-ns1.yml
+++ b/jail-ns1.yml
@@ -6,5 +6,4 @@
   sudo: yes
   roles:
   - base
-  - sendmail
   - dns

--- a/jail-www.yml
+++ b/jail-www.yml
@@ -10,7 +10,6 @@
 
   roles:
   - base
-  - sendmail
   - role: packages
     packages:
     - node

--- a/roles/base/defaults/main.yml
+++ b/roles/base/defaults/main.yml
@@ -2,3 +2,7 @@
 # set this to False to skip configuring syslog (on a host with a special syslog
 # configuration)
 configure_syslog: True
+
+# set this to False to skip configuring sendmail (in cases where it is manually
+# configured or another MTA is in use)
+configure_sendmail: True

--- a/roles/base/handlers/main.yml
+++ b/roles/base/handlers/main.yml
@@ -4,5 +4,10 @@
     name: syslogd
     state: reloaded
 
+- name: reload sendmail
+  service:
+    name: sendmail
+    state: restarted
+
 - name: newaliases
   command: /usr/bin/newaliases

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -2,5 +2,6 @@
 - include: packages.yml
 - include: sudo.yml
 - include: syslog.yml
+- include: sendmail.yml
 - include: rootpw.yml
 - include: ansible-pull.yml

--- a/roles/base/tasks/sendmail.yml
+++ b/roles/base/tasks/sendmail.yml
@@ -10,6 +10,7 @@
     - {option: "sendmail_submit_enable", value: "NO"}
     - {option: "sendmail_outbound_enable", value: "YES"}
     - {option: "sendmail_msp_queue_enable", value: "YES"}
+  when: configure_sendmail
 
 - name: update root mail alias
   lineinfile:
@@ -18,9 +19,12 @@
     regexp: "^#?root:"
     state: present
   notify: newaliases
+  when: configure_sendmail
 
 - name: start sendmail
   service:
     name: sendmail
     enabled: true
     state: running
+  when: configure_sendmail
+

--- a/roles/sendmail/handlers/main.yml
+++ b/roles/sendmail/handlers/main.yml
@@ -1,8 +1,0 @@
----
-- name: reload sendmail
-  service:
-    name: sendmail
-    state: restarted
-
-- name: newaliases
-  command: /usr/bin/newaliases


### PR DESCRIPTION
Except on hosts that do explicit mail handling (lists, mx), where the
config is disabled.  This gets us the proper sendmail config on all of
the otherwise-unmanaged jails.