### PR TITLE
configure syslog server with syslog-ng

### DIFF
--- a/jail-syslog.yml
+++ b/jail-syslog.yml
@@ -1,5 +1,4 @@
 ---
-# TODO: actually manage configuration (#3135)
 - name: configure syslog
   hosts: syslog
   gather_facts: no
@@ -10,4 +9,4 @@
       # don't add the base configuration for syslog here, as this host
       # has its own syslog configuration
       configure_syslog: False
-
+    - syslog-aggregator

--- a/roles/syslog-aggregator/handlers/main.yml
+++ b/roles/syslog-aggregator/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: reload syslog-ng
+  service:
+    name: syslog-ng
+    state: restarted
+

--- a/roles/syslog-aggregator/tasks/main.yml
+++ b/roles/syslog-aggregator/tasks/main.yml
@@ -1,0 +1,36 @@
+# Configure Buildbot syslog aggregator
+---
+- name: disable and stop the syslogd service
+  service:
+    name: syslogd
+    enabled: false
+    state: stopped
+
+- name: install syslog-ng
+  pkgng:
+    name: syslog-ng
+    state: present
+
+- name: configure syslog-ng
+  template:
+    src: "{{ item }}.j2"
+    dest: "/usr/local/etc/{{ item }}"
+  with_items:
+    - syslog-ng-buildbot.conf
+    - syslog-ng.conf
+  notify: reload syslog-ng
+
+- name: install log cleanup crontask
+  cron:
+    name: log-cleanup
+    user: root
+    job: "find /data/log -mtime +28 -type f -exec ls {} \\;"
+    minute: 0
+    hour: 0
+    state: present
+
+- name: enable and start syslog-ng service
+  service:
+    name: syslog-ng
+    enabled: true
+    state: running

--- a/roles/syslog-aggregator/tasks/main.yml
+++ b/roles/syslog-aggregator/tasks/main.yml
@@ -24,7 +24,7 @@
   cron:
     name: log-cleanup
     user: root
-    job: "find /data/log -mtime +28 -type f -exec ls {} \\;"
+    job: "find {{ log_root }} -mtime +28 -type f -exec ls {} \\;"
     minute: 0
     hour: 0
     state: present

--- a/roles/syslog-aggregator/templates/syslog-ng-buildbot.conf.j2
+++ b/roles/syslog-aggregator/templates/syslog-ng-buildbot.conf.j2
@@ -10,7 +10,7 @@ source src_net {
 };
 
 destination per_host {
-    file("/data/log/$HOST/$YEAR-$MONTH-$DAY.log"
+    file("{{ log_root }}/$HOST/$YEAR-$MONTH-$DAY.log"
         owner(root)
         group(root)
         perm(0644)

--- a/roles/syslog-aggregator/templates/syslog-ng-buildbot.conf.j2
+++ b/roles/syslog-aggregator/templates/syslog-ng-buildbot.conf.j2
@@ -1,0 +1,29 @@
+# Aggregate inputs from hosts on the network, putting them in named files
+
+options {
+    create_dirs(yes);
+};
+
+source src_net {
+    udp();
+    tcp();
+};
+
+destination per_host {
+    file("/data/log/$HOST/$YEAR-$MONTH-$DAY.log"
+        owner(root)
+        group(root)
+        perm(0644)
+        dir_perm(0755)
+        create_dirs(yes));
+};
+
+log {
+    source(src_net);
+    destination(per_host);
+};
+
+log {
+    source(src_local);
+    destination(per_host);
+};

--- a/roles/syslog-aggregator/templates/syslog-ng.conf.j2
+++ b/roles/syslog-aggregator/templates/syslog-ng.conf.j2
@@ -1,0 +1,182 @@
+@version:3.6
+@include "scl.conf"
+@include "syslog-ng-buildbot.conf"
+
+# Modified from the sample:
+#   rename 'src' to 'src_local' and omit udp() in that source
+# Otherwise, this behaves equivalently to the stock FreeBSD syslog.conf
+
+#
+# options
+#
+options { chain_hostnames(off); flush_lines(0); threaded(yes); };
+
+#
+# sources
+#
+source src_local { system(); internal(); };
+
+#
+# destinations
+#
+destination messages { file("/var/log/messages"); };
+destination security { file("/var/log/security"); };
+destination authlog { file("/var/log/auth.log"); };
+destination maillog { file("/var/log/maillog"); };
+destination lpd-errs { file("/var/log/lpd-errs"); };
+destination xferlog { file("/var/log/xferlog"); };
+destination cron { file("/var/log/cron"); };
+destination debuglog { file("/var/log/debug.log"); };
+destination consolelog { file("/var/log/console.log"); };
+destination all { file("/var/log/all.log"); };
+destination newscrit { file("/var/log/news/news.crit"); };
+destination newserr { file("/var/log/news/news.err"); };
+destination newsnotice { file("/var/log/news/news.notice"); };
+destination slip { file("/var/log/slip.log"); };
+destination ppp { file("/var/log/ppp.log"); };
+destination console { file("/dev/console"); };
+destination allusers { usertty("*"); };
+#destination loghost { udp("loghost" port(514)); };
+
+#
+# log facility filters
+#
+filter f_auth { facility(auth); };
+filter f_authpriv { facility(authpriv); };
+filter f_not_authpriv { not facility(authpriv); };
+#filter f_console { facility(console); };
+filter f_cron { facility(cron); };
+filter f_daemon { facility(daemon); };
+filter f_ftp { facility(ftp); };
+filter f_kern { facility(kern); };
+filter f_lpr { facility(lpr); };
+filter f_mail { facility(mail); };
+filter f_news { facility(news); };
+filter f_security { facility(security); };
+filter f_user { facility(user); };
+filter f_uucp { facility(uucp); };
+filter f_local0 { facility(local0); };
+filter f_local1 { facility(local1); };
+filter f_local2 { facility(local2); };
+filter f_local3 { facility(local3); };
+filter f_local4 { facility(local4); };
+filter f_local5 { facility(local5); };
+filter f_local6 { facility(local6); };
+filter f_local7 { facility(local7); };
+
+#
+# log level filters
+#
+filter f_emerg { level(emerg); };
+filter f_alert { level(alert..emerg); };
+filter f_crit { level(crit..emerg); };
+filter f_err { level(err..emerg); };
+filter f_warning { level(warning..emerg); };
+filter f_notice { level(notice..emerg); };
+filter f_info { level(info..emerg); };
+filter f_debug { level(debug..emerg); };
+filter f_is_debug { level(debug); };
+
+#
+# program filters
+#
+filter f_ppp { program("ppp"); };
+filter f_slip { program("startslip"); };
+
+#
+# *.err;kern.warning;auth.notice;mail.crit		/dev/console
+#
+log { source(src_local); filter(f_err); destination(console); };
+log { source(src_local); filter(f_kern); filter(f_warning); destination(console); };
+log { source(src_local); filter(f_auth); filter(f_notice); destination(console); };
+log { source(src_local); filter(f_mail); filter(f_crit); destination(console); };
+
+#
+# *.notice;authpriv.none;kern.debug;lpr.info;mail.crit;news.err	/var/log/messages
+#
+log { source(src_local); filter(f_notice); filter(f_not_authpriv); destination(messages); };
+log { source(src_local); filter(f_kern); filter(f_debug); destination(messages); };
+log { source(src_local); filter(f_lpr); filter(f_info); destination(messages); };
+log { source(src_local); filter(f_mail); filter(f_crit); destination(messages); };
+log { source(src_local); filter(f_news); filter(f_err); destination(messages); };
+
+#
+# security.*						/var/log/security
+#
+log { source(src_local); filter(f_security); destination(security); };
+
+#
+# auth.info;authpriv.info				/var/log/auth.log
+log { source(src_local); filter(f_auth); filter(f_info); destination(authlog); };
+log { source(src_local); filter(f_authpriv); filter(f_info); destination(authlog); };
+
+#
+# mail.info						/var/log/maillog
+#
+log { source(src_local); filter(f_mail); filter(f_info); destination(maillog); };
+
+#
+# lpr.info						/var/log/lpd-errs
+#
+log { source(src_local); filter(f_lpr); filter(f_info); destination(lpd-errs); };
+
+#
+# ftp.info						/var/log/xferlog
+#
+log { source(src_local); filter(f_ftp); filter(f_info); destination(xferlog); };
+
+#
+# cron.*						/var/log/cron
+#
+log { source(src_local); filter(f_cron); destination(cron); };
+
+#
+# *.=debug						/var/log/debug.log
+#
+log { source(src_local); filter(f_is_debug); destination(debuglog); };
+
+#
+# *.emerg						*
+#
+log { source(src_local); filter(f_emerg); destination(allusers); };
+
+#
+# uncomment this to log all writes to /dev/console to /var/log/console.log
+# console.info						/var/log/console.log
+#
+#log { source(src_local); filter(f_console); filter(f_info); destination(consolelog); };
+
+#
+# uncomment this to enable logging of all log messages to /var/log/all.log
+# touch /var/log/all.log and chmod it to mode 600 before it will work
+# *.*							/var/log/all.log
+#
+#log { source(src_local); destination(all); };
+
+#
+# uncomment this to enable logging to a remote loghost named loghost
+# *.*							@loghost
+#
+#log { source(src_local); destination(loghost); };
+
+#
+# uncomment these if you're running inn
+# news.crit						/var/log/news/news.crit
+# news.err						/var/log/news/news.err
+# news.notice						/var/log/news/news.notice
+#
+#log { source(src_local); filter(f_news); filter(f_crit); destination(newscrit); };
+#log { source(src_local); filter(f_news); filter(f_err); destination(newserr); };
+#log { source(src_local); filter(f_news); filter(f_notice); destination(newsnotice); };
+
+#
+# !startslip
+# *.*							/var/log/slip.log
+#
+log { source(src_local); filter(f_slip); destination(slip); };
+
+#
+# !ppp
+# *.*							/var/log/ppp.log
+#
+log { source(src_local); filter(f_ppp); destination(ppp); };

--- a/roles/syslog-aggregator/vars/main.yml
+++ b/roles/syslog-aggregator/vars/main.yml
@@ -1,0 +1,2 @@
+---
+log_root: /data/log


### PR DESCRIPTION
I've tested this in my local jail.  This will disable the existing syslog config on the production jail, then install and enable syslog-ng.