### PR TITLE
Set DNS TTLs to one day

### DIFF
--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -1,48 +1,51 @@
+$TTL            86400
 @       86400   IN      SOA     ns1.buildbot.net. hostmaster.buildbot.net. (
                                         2015012201      ;serial
                                         10800           ;refresh
                                         1800            ;retry
                                         604800          ;expire
                                         86400   )       ;minimum
-@               7200    IN      NS      c.ns.buddyns.com.   ; germany
-@               7200    IN      NS      f.ns.buddyns.com.   ; india
-@               7200    IN      NS      ns1.rtems.org.      ; usa
-@               7200    IN      NS      ns1.darkbeer.org.   ; usa
-@               86400   IN      MX      10 mx.buildbot.net.
-@               7200    IN      A       140.211.10.238
-buildbot        7200    IN      A       140.211.10.239
-meetings        43200   IN      CNAME   ds0210.flosoft-servers.net.
-xy2dwhhhx5d4    7200    IN      CNAME   gv-d47fzorbndt4i4.dv.googlehosted.com.
-mx              86400   IN      A       140.211.10.235
-www             7200    IN      CNAME   buildbot.net.
-www-new         7200    IN      CNAME   buildbot.net.
-lists           86400   IN      A       140.211.10.241
-trac            86400   IN      A       140.211.10.240
-ftp             86400   IN      A       140.211.10.243
-bot             86400   IN      A       140.211.10.242
-service1        86400   IN      A       140.211.10.230
-service2        86400   IN      A       140.211.10.231
-service3        86400   IN      A       140.211.10.232
-vm1             86400   IN      A       140.211.10.233
-mac1            86400   IN      A       140.211.10.234
-ns1             86400   IN      A       140.211.10.236
-docs            86400   IN      A       140.211.10.237
-nine            86400   IN      A       140.211.10.244
+
+
+@               IN      NS      c.ns.buddyns.com.   ; germany
+@               IN      NS      f.ns.buddyns.com.   ; india
+@               IN      NS      ns1.rtems.org.      ; usa
+@               IN      NS      ns1.darkbeer.org.   ; usa
+@               IN      MX      10 mx.buildbot.net.
+@               IN      A       140.211.10.238
+buildbot        IN      A       140.211.10.239
+meetings        IN      CNAME   ds0210.flosoft-servers.net.
+xy2dwhhhx5d4    IN      CNAME   gv-d47fzorbndt4i4.dv.googlehosted.com.
+mx              IN      A       140.211.10.235
+www             IN      CNAME   buildbot.net.
+www-new         IN      CNAME   buildbot.net.
+lists           IN      A       140.211.10.241
+trac            IN      A       140.211.10.240
+ftp             IN      A       140.211.10.243
+bot             IN      A       140.211.10.242
+service1        IN      A       140.211.10.230
+service2        IN      A       140.211.10.231
+service3        IN      A       140.211.10.232
+vm1             IN      A       140.211.10.233
+mac1            IN      A       140.211.10.234
+ns1             IN      A       140.211.10.236
+docs            IN      A       140.211.10.237
+nine            IN      A       140.211.10.244
 
 ; Our "internal" addreses.  Note that we do not use split DNS. Also note that
 ; there is no reverse resolution for these addresses.
 
 $ORIGIN int.buildbot.net.
-backup          86400   IN      A       192.168.80.212
-bslave1         86400   IN      A       192.168.80.226
-buildbot        86400   IN      A       192.168.80.239
-docs            86400   IN      A       192.168.80.237
-mx              86400   IN      A       192.168.80.235
-ns1             86400   IN      A       192.168.80.236
-syslog          86400   IN      A       192.168.80.211
-www             86400   IN      A       192.168.80.238
-trac            86400   IN      A       192.168.80.240
-lists           86400   IN      A       192.168.80.241
-bot             86400   IN      A       192.168.80.242
-ftp             86400   IN      A       192.168.80.243
-nine            86400   IN      A       192.168.80.244
+backup          IN      A       192.168.80.212
+bslave1         IN      A       192.168.80.226
+buildbot        IN      A       192.168.80.239
+docs            IN      A       192.168.80.237
+mx              IN      A       192.168.80.235
+ns1             IN      A       192.168.80.236
+syslog          IN      A       192.168.80.211
+www             IN      A       192.168.80.238
+trac            IN      A       192.168.80.240
+lists           IN      A       192.168.80.241
+bot             IN      A       192.168.80.242
+ftp             IN      A       192.168.80.243
+nine            IN      A       192.168.80.244


### PR DESCRIPTION
I just got an email from buddyns that we've used 180,000 queries so far this month (15 days).  That seems a bit high for the traffic that we get!  Increasing the TTL should allow more caching on resolving nameservers.