### PR TITLE
Drop buddyns, which has a very low monthly query limit

### DIFF
--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -1,14 +1,14 @@
 $TTL            86400
 @       86400   IN      SOA     ns1.buildbot.net. hostmaster.buildbot.net. (
-                                        2015012201      ;serial
+                                        2015022301      ;serial
                                         10800           ;refresh
                                         1800            ;retry
                                         604800          ;expire
                                         86400   )       ;minimum
 
 
-@               IN      NS      c.ns.buddyns.com.   ; germany
-@               IN      NS      f.ns.buddyns.com.   ; india
+@               IN      NS      ns1.he.net.         ; usa
+@               IN      NS      ns5.he.net.         ; london
 @               IN      NS      ns1.rtems.org.      ; usa
 @               IN      NS      ns1.darkbeer.org.   ; usa
 @               IN      MX      10 mx.buildbot.net.


### PR DESCRIPTION
We are hitting the 270kq limit in this, the shortest month of the year.

HE fixed things just after we switched away from them, and have been silently keeping up to date since, so I'm willing to go back.