### PR TITLE
Enable SPDY when using SSL

### DIFF
--- a/roles/nginx/templates/static
+++ b/roles/nginx/templates/static
@@ -24,7 +24,7 @@ server {
 }
 {% if ssl %}
 server {
-    listen 443 ssl;
+    listen 443 ssl spdy;
     server_name {{server_name}};
 
     # based on https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx


### PR DESCRIPTION
SPDY can provide some nice speedups when using SSL that should help nine once SSL is enabled everywhere.