### PR TITLE
Make /etc/ssl/cert.pem exist for Python's benefit

### DIFF
--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -6,3 +6,4 @@
 - include: rootpw.yml
 - include: ansible-pull.yml
 - include: periodic.yml
+- include: python-cert-symlink.yml

--- a/roles/base/tasks/python-cert-symlink.yml
+++ b/roles/base/tasks/python-cert-symlink.yml
@@ -1,0 +1,5 @@
+- name: add /etc/ssl/cert.pem for Python-2.7.9's benefit
+  file:
+    path: /etc/ssl/cert.pem
+    state: link
+    src: /usr/local/etc/ssl/cert.pem


### PR DESCRIPTION
Python-2.7.9 now validates all certs, but it looks for its list of
recognized CAs in /etc/ssl/cert.pem, rather than under /usr/local.
See http://lists.freebsd.org/pipermail/freebsd-python/2015-January/007832.html

I added this link (via ln, not Ansible) on trac.buidlbot.net and it fixed the reCAPTCHA failures.