### PR TITLE
The line got outdented one level somehow

### DIFF
--- a/jail-bslave1.yml
+++ b/jail-bslave1.yml
@@ -55,7 +55,7 @@
     bb_env_dir: "{{ getent_passwd[worker_account].4 }}/{{ buildbot_net.bb_slave_name }}/{{ env_name }}"
     bb_slave_dir: "{{ getent_passwd[worker_account].4 }}/{{ buildbot_net.bb_slave_name }}/{{ buildbot_net.bb_slave_dir }}"
   - role: supervisor-service
-  service_name: "{{ buildbot_net.slave_service_name }}"
+    service_name: "{{ buildbot_net.slave_service_name }}"
     service_dir: "{{ getent_passwd[worker_account].4 }}/{{ buildbot_net.bb_slave_name }}/{{ buildbot_net.bb_slave_dir }}"
     service_command: "{{ getent_passwd[worker_account].4 }}/{{ buildbot_net.bb_slave_name }}/{{ env_name }}/bin/buildslave start --nodaemon"
     service_user: "{{ worker_account }}"


### PR DESCRIPTION
Plays are failing:

    ERROR: Syntax Error while loading YAML script, /home/bbinfra/repo/jail-bslave1.yml 
    Note: The error may actually appear before this position: line 59, column 5        
                                                                                       
      service_name: "{{ buildbot_net.slave_service_name }}"                            
        service_dir: "{{ getent_passwd[worker_account].4 }}/{{ buildbot_net.bb_slave_name }}/{{ buildbot_net.bb_slave_dir }}"                                                 
        ^                                                                              
    We could be wrong, but this one looks like it might be an issue with               
    missing quotes.  Always quote template expression brackets when they               
    start a value. For instance:                                                       
                                                                                       
        with_items:                                                                    
          - {{ foo }}                                                                  
                                                                                       
    Should be written as:                                                              
                                                                                       
        with_items:                                                                    
          - "{{ foo }}"                                                                

That's not quite the issue; it's because the previous line isn't indented right.