### PR TITLE
Add TLS support to proxied sites

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -84,6 +84,12 @@
     dest: "{{ nginx_conf_dir }}/nginx.conf"
   notify: reload nginx
 
+- name: install ssl configuration file
+  template:
+    src: "ssl.conf"
+    dest: "{{ nginx_conf_dir }}/conf.d/ssl.conf"
+  notify: reload nginx
+
 - name: enable and start nginx service
   service:
     name: nginx

--- a/roles/nginx/templates/proxy
+++ b/roles/nginx/templates/proxy
@@ -32,3 +32,47 @@ server {
         root /usr/local/www/nginx-dist;
     }
 }
+{% if ssl %}
+server {
+    listen 443 ssl;
+    server_name {{server_name}};
+
+    # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
+    ssl_certificate {{ nginx_cert_dir }}/{{ server_name }}.crt;
+    ssl_certificate_key {{ nginx_cert_dir }}/{{ server_name }}.key;
+    ssl_session_timeout 5m;
+    ssl_session_cache shared:SSL:5m;
+
+    include conf.d/ssl.conf
+
+    access_log {{nginx_log_dir}}/{{server_name}}/ssl-access.log;
+    error_log {{nginx_log_dir}}/{{server_name}}/ssl-error.log;
+
+    location / {
+        proxy_pass http://{{upstream_url}};
+
+        # +++ NOTE(sa2ajj): these need to be reviewed (trying to fix the errors
+        # shown in error.log)
+        proxy_buffering off;
+
+        proxy_read_timeout 600;
+        chunked_transfer_encoding off;
+        proxy_cache off;
+        # ---
+
+        # These three lines would be required for web socket proxying
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection "upgrade";
+    }
+
+    #error_page 404 /404.html;
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page 500 502 503 504  /50x.html;
+    location = /50x.html {
+        root /usr/local/www/nginx-dist;
+    }
+}
+{% endif %}

--- a/roles/nginx/templates/ssl.conf
+++ b/roles/nginx/templates/ssl.conf
@@ -1,0 +1,23 @@
+# Based on https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx.
+
+# Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
+ssl_dhparam {{ nginx_conf_dir }}/dhparam.pem;
+
+# Modern configuration.
+ssl_protocols TLSv1.1 TLSv1.2;
+ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
+ssl_prefer_server_ciphers on;
+
+# TODO: support HSTS, OCSP staplingo
+
+
+# EnabLE THIS If your want HSTS (recommended)
+# add_header Strict-Transport-Security max-age=15768000;
+
+# OCSP Stapling ---
+# fetch OCSP records from URL in ssl_certificate and cache them
+ssl_stapling off;
+ssl_stapling_verify off;
+## verify chain of trust of OCSP response using Root CA and Intermediate certs
+#ssl_trusted_certificate /path/to/root_CA_cert_plus_intermediates;
+#resolver <IP DNS resolver>;

--- a/roles/nginx/templates/static
+++ b/roles/nginx/templates/static
@@ -27,7 +27,6 @@ server {
     listen 443 ssl;
     server_name {{server_name}};
 
-    # based on https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
 
     # certs sent to the client in SERVER HELLO are concatenated in ssl_certificate
     ssl_certificate {{ nginx_cert_dir }}/{{ server_name }}.crt;
@@ -35,27 +34,7 @@ server {
     ssl_session_timeout 5m;
     ssl_session_cache shared:SSL:5m;
 
-    # Diffie-Hellman parameter for DHE ciphersuites, recommended 2048 bits
-    ssl_dhparam {{ nginx_conf_dir }}/dhparam.pem;
-
-    # Modern configuration.
-    ssl_protocols TLSv1.1 TLSv1.2;
-    ssl_ciphers 'ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:!MD5:!PSK';
-    ssl_prefer_server_ciphers on;
- 
-    # TODO: support HSTS, OCSP staplingo
-
-
-    # EnabLE THIS If your want HSTS (recommended)
-    # add_header Strict-Transport-Security max-age=15768000;
- 
-    # OCSP Stapling ---
-    # fetch OCSP records from URL in ssl_certificate and cache them
-    ssl_stapling off;
-    ssl_stapling_verify off;
-    ## verify chain of trust of OCSP response using Root CA and Intermediate certs
-    #ssl_trusted_certificate /path/to/root_CA_cert_plus_intermediates;
-    #resolver <IP DNS resolver>;
+    include conf.d/ssl.conf
 
     access_log {{nginx_log_dir}}/{{server_name}}/ssl-access.log;
     error_log {{nginx_log_dir}}/{{server_name}}/ssl-error.log;


### PR DESCRIPTION
The one part that was missing still for TLS were the proxied Buildbot instances. I moved the TLS configuration to a separate file so the static and proxy configurations won't drift.