### PR TITLE
Send weekly status emails from the trac jail

### DIFF
--- a/files/weekly-summary.py
+++ b/files/weekly-summary.py
@@ -26,6 +26,8 @@ TRAC_BUILDBOT_URL = 'http://trac.buildbot.net'
 TRAC_BUILDBOT_TICKET_URL = TRAC_BUILDBOT_URL + '/ticket/%(ticket)s'
 GITHUB_API_URL = 'https://api.github.com'
 HTTP_HEADERS = Headers({'User-Agent': ['buildbot.net weekly summary']})
+FROM = 'dustin@buildbot.net'
+RECIPIENTS = ['devel@buildbot.net', 'users@buildbot.net']
 
 email = textwrap.dedent("""\
     <html>
@@ -257,11 +259,10 @@ def make_html(results):
 def send_email(html):
     msg = MIMEText(html, 'html')
     msg['Subject'] = "Buildbot Weekly Summary"
-    msg['From'] = 'dustin@buildbot.net'
-    recips = ['devel@buildbot.net', 'users@buildbot.net']
-    msg['To'] = ', '.join(recips)
+    msg['From'] = FROM
+    msg['To'] = ', '.join(RECIPIENTS)
     s = smtplib.SMTP('localhost')
-    s.sendmail(msg['From'], recips, msg.as_string())
+    s.sendmail(msg['From'], RECIPIENTS, msg.as_string())
     s.quit()
 
 def main():

--- a/jail-trac.yml
+++ b/jail-trac.yml
@@ -1,5 +1,5 @@
 ---
-# TODO: actually manage configuration (#3038)
+# TODO: actually manage Trac configuration (#3038)
 - name: configure trac
   hosts: trac
   gather_facts: no
@@ -7,3 +7,30 @@
   sudo: yes
   roles:
   - base
+  - role: user
+    user_id: emailer
+    user_name: Email Sender
+  - role: virtualenv
+    venv_user: emailer
+    venv_home_dir: /home/emailer
+    venv_name: weekly-summary
+    venv_python_packages:
+    - Twisted
+    - PyOpenSSL
+    - service_identity
+  tasks:
+  - name: install weekly-summary script
+    copy:
+      src: files/weekly-summary.py
+      dest: /home/emailer/weekly-summary/weekly-summary.py
+      mode: 0777
+  
+  - name: install weekly-summary crontask
+    cron:
+      name: send-weekly-summary
+      job: "cd /home/emailer/weekly-summary/; bin/python weekly-summary.py"
+      user: emailer
+      # run a bit before the weekly meeting
+      minute: 0
+      hour: 15
+      weekday: 2


### PR DESCRIPTION
.. instead of dustin's desktop

This leaves the door open to send other emails from trac, too.  For
example, we could do a daily list of pull requests that are pending
review or merge, and which haven't been touched for, say, 24 hours.

See trac bug 3082