### PR TITLE
Add missing packages from the virtualenv

### DIFF
--- a/jail-docs.yml
+++ b/jail-docs.yml
@@ -25,9 +25,12 @@
     - jpeg
     venv_python_packages:
     - 'docutils>=0.8'
+    - 'funcparserlib==0.3.6'
+    - 'Pillow==3.1.0'
     - 'Pygments==2.0.1'   # This seems to be redundant since sphinx depends on Pygments
     - 'sphinx==1.2.2'
     - 'sphinxcontrib-blockdiag'
+    - 'webcolors==1.5'
   - role: simple-buildout
     repo_url: git://github.com/buildbot/bbdocs.git
     repo_branch: master


### PR DESCRIPTION
Unsure why these aren't in the virtualenv. The docs builder uses only `sphinxcontrib-blockdiag` and `docutils>=0.8` yet gets everything however this doesn't. These are the remaining packages and versions as of the latest docs build (#270 from today).