### PR TITLE
Remove knuth* workers

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -61,7 +61,6 @@ root_email_destination: "sysadmin@buildbot.net"
 # This structure refers to `build_slaves` in `secrets.yml`
 slave_master_allocations:
   nine:
-  - knuth
   - buildbot-linux4
   - bslave1
   master:
@@ -72,7 +71,6 @@ slave_master_allocations:
   - centos_5_python2_4
   - debian
   - freebsd_7
-  - knuth.r.igoro.us
   - koobs-freebsd10
   - koobs-freebsd9
   - linux


### PR DESCRIPTION
I don't see when the knuth buildslaves were removed but they're no longer in secrets but still in `group_vars/all`.