### PR TITLE
Restart the service when the certificate changes

### DIFF
--- a/roles/nginx/tasks/main.yml
+++ b/roles/nginx/tasks/main.yml
@@ -55,6 +55,7 @@
   copy:
     content: "{{ ssl_keys[server_name]['cert'] }}"
     dest: "{{ nginx_cert_dir }}/{{ server_name }}.crt"
+  notify: reload nginx
   when: ssl
 
 - name: create ssl key file

--- a/roles/vsftp/tasks/main.yml
+++ b/roles/vsftp/tasks/main.yml
@@ -18,6 +18,7 @@
     mode: 0600
     owner: root
     group: wheel
+  notify: restart vsftpd
   when: ssl
 
 - name: create ssl key file


### PR DESCRIPTION
The certificate changed but docs.buildbot.net still has the old certificate.