### PR TITLE
redirect from removed cls-forcesched.html page to appropriate section in schedulers docs

### DIFF
--- a/files/www-redirects
+++ b/files/www-redirects
@@ -17,3 +17,5 @@ rewrite ^/buildbot/docs/(latest|current)/WithProperties.html http://docs.buildbo
 rewrite ^/buildbot/docs/(latest|current)/release-notes.html http://docs.buildbot.net/$1/relnotes/index.html permanent;
 rewrite ^/buildbot/docs/(latest|current)/release-notes/(.*) http://docs.buildbot.net/$1/relnotes/$2 permanent;
 rewrite ^/buildbot/docs(.*)$ http://docs.buildbot.net$1 permanent;
+# Renamed documentation pages.
+rewrite ^/latest/developer/cls-forcesched.html http://docs.buildbot.net/latest/manual/cfg-schedulers.html#forcescheduler-scheduler permanent;


### PR DESCRIPTION
Needed for https://github.com/buildbot/buildbot/pull/2145

Related issue http://trac.buildbot.net/ticket/3530

**Haven't tested at all! Will this work as I expect?**
