### PR TITLE
Allow world readable tmpfiles

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -5,6 +5,7 @@ ansible_managed = Managed by Ansible
 deprecation_warnings = True
 error_on_undefined_vars = True
 legacy_playbook_variables = no
+allow_world_readable_tmpfiles = True
 
 display_skipped_hosts = no
 


### PR DESCRIPTION
See http://trac.buildbot.net/ticket/3576#comment:3 for more details.
Short version is the `acls` option needs to be specified for the mount,
they aren't, so setfacl will fail.

This is a potential security issue, if untrusted people have access to
the temp files. Anything private would be in the jails where only people
with root have access at the moment so it's acceptable.