### PR TITLE
Set our own limit for ansible-pull

### DIFF
--- a/roles/base/templates/run-ansible-pull.sh.j2
+++ b/roles/base/templates/run-ansible-pull.sh.j2
@@ -26,6 +26,7 @@ while [[ $RETRY -lt $RETRIES ]]; do
         -U {{ ansible_git_repository }} \
         -i localhost \
         --vault-password-file=/home/{{ service_account }}/.vault-password \
+        -l "localhost,$(hostname),127.0.0.1"
         local.yml >$OUTPUT 2>&1
     RESULT=$?
     set -e


### PR DESCRIPTION
Ansible has a default of "localhost,<hostnames>,127.0.0.1" for the limit option. On docs, the hostnames includes "docs,docs.buildbot.net". The "docs" part is the issue. Not including it causes ansible to run successfully. Using the --limit option causes the default to be overriden so do that and construct it to drop the "docs" part.

Fixes ticket:3576, I think.