### PR TITLE
Update syslog-ng base config file

### DIFF
--- a/roles/syslog-aggregator/templates/syslog-ng.conf.j2
+++ b/roles/syslog-aggregator/templates/syslog-ng.conf.j2
@@ -1,4 +1,4 @@
-@version:3.6
+@version:3.7
 @include "scl.conf"
 @include "syslog-ng-buildbot.conf"
 


### PR DESCRIPTION
This file worked fine for a long time, but puts syslog-ng in
compatibility mode, which apparently stopped working recently.

This is based on the freebsd default, but with some modifications.  The
new version is based on the default provided with the latest version
(3.7.3_4).