### PR TITLE
Retry buildout commands that fail

### DIFF
--- a/roles/simple-buildout/tasks/main.yml
+++ b/roles/simple-buildout/tasks/main.yml
@@ -16,5 +16,20 @@
     chdir: "{{ target_dir }}"
   with_items: target_commands
   when: "repo_state|changed"
+  register: command_result
+  ignore_errors: true
+
+# if the command failed, roll the git repository back one commit so that
+# on the next run, we will re-run the build
+- name: Revert git repo
+  become_user: "{{ target_user }}"
+  command: "git reset --hard HEAD^"
+  args:
+    chdir: "{{ target_dir }}"
+  when: "command_result.rc != 0"
+
+- name: Indicate failure
+  fail: msg="the buildout command failed"
+  when: "command_result.rc != 0"
 
 # vim:ts=2:sw=2:noai:nosi


### PR DESCRIPTION
If a buildout command fails, we want to retry it on the next run.  This
bumps the git repository back to the previous revision so that on the
next Ansible run it will change, and thus re-run the command.