### PR TITLE
Install python meta-package

### DIFF
--- a/jail-docs.yml
+++ b/jail-docs.yml
@@ -20,6 +20,8 @@
     venv_user: "{{ worker_account }}"
     venv_home_dir: "{{ getent_passwd[worker_account].4 }}"
     venv_name: "{{ env_name }}"
+    venv_python_packages:
+    - pip
     venv_packages:
     - gmake
     - jpeg

--- a/jail-docs.yml
+++ b/jail-docs.yml
@@ -23,6 +23,7 @@
     venv_packages:
     - gmake
     - jpeg
+    - python
   - role: simple-buildout
     repo_url: git://github.com/buildbot/bbdocs.git
     repo_branch: master


### PR DESCRIPTION
The Makefile for docs calls 'python' so the python executable needs to be available to build docs.