### PR TITLE
Fix ssh role

### DIFF
--- a/jail-ftp.yml
+++ b/jail-ftp.yml
@@ -13,7 +13,8 @@
   # run a specialized SSH daemon to receive uploads from other internal hosts
   - role: ssh
     sshd_port: 2200
-    listen_address: "{{ internal_ip }}"
+    listen_addresses:
+      - "{{ internal_ip }}"
     extra_config: |
         Match User buildbot
             ChrootDirectory {{ ftp_root }}

--- a/roles/ssh/defaults/main.yml
+++ b/roles/ssh/defaults/main.yml
@@ -3,5 +3,5 @@
 sshd_port: 22
 listen_addresses:
     - "{{ ansible_default_ipv4.address }}"
-    - "{{ internal_ip }}"
+    - "{{ internal_ip | default(None) }}"
 extra_config:

--- a/roles/ssh/templates/sshd_config.j2
+++ b/roles/ssh/templates/sshd_config.j2
@@ -1,6 +1,8 @@
 Port {{ sshd_port }}
 {% for listen_address in listen_addresses %}
+{% if listen_address %}
 ListenAddress {{ listen_address }}
+{% endif %}
 {% endfor %}
 # these are always disabled
 PermitRootLogin no


### PR DESCRIPTION
Default `internal_ip` to None and skip if it is None. I don't know how this interacts with the vagrant development. It may be more useful to have this default to something automatically. I opted for this because it then matches what is already existing.

The second part is simpler: `listen_address` changed to `listen_addresses` and one spot was missed.