### PR TITLE
generate named configuration from hosts config

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -144,6 +144,9 @@ nat_if: ""  # none: needed only for vagrant
 internal_if: vlan0
 external_if: lagg0
 
+# needs to be changed each time the dns config is updated
+dns_serial: 2016091701  # YYYYMMDD01
+
 # IP addresses for all hosts in the network
 hosts_ips:
     events  : 227

--- a/group_vars/all
+++ b/group_vars/all
@@ -164,10 +164,10 @@ hosts_ips:
     nine    : 244
     supybot : 245
     mysql   : 246
+    syslog : 211
 
     backup : 212
     bslave1: 226
-    syslog : 211
     build1 : 210
 
 # vars are lazily evaluated so ansible_hostname will be valid at the time of evaluation (via gatherfacts)

--- a/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
+++ b/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
@@ -9,34 +9,6 @@
 @               7200    IN      NS      ns1.rtems.org.      ; usa
 @               7200    IN      NS      ns1.darkbeer.org.   ; usa
 
-;224
-;225
-;226
-227     86400   IN       PTR     events.buildbot.net.
-;228
-;229
-230     86400   IN       PTR     service1.buildbot.net.
-231     86400   IN       PTR     service2.buildbot.net.
-232     86400   IN       PTR     service3.buildbot.net.
-233     86400   IN       PTR     vm1.buildbot.net.
-234     86400   IN       PTR     mac1.buildbot.net.
-235     86400   IN       PTR     mx.buildbot.net.
-236     86400   IN       PTR     ns1.buildbot.net.
-237     86400   IN       PTR     docs.buildbot.net.
-238     86400   IN       PTR     www.buildbot.net.
-239     86400   IN       PTR     buildbot.buildbot.net.
-240     86400   IN       PTR     trac.buildbot.net.
-241     86400   IN       PTR     lists.buildbot.net.
-242     86400   IN       PTR     bot.buildbot.net.
-243     86400   IN       PTR     ftp.buildbot.net.
-244     86400   IN       PTR     nine.buildbot.net.
-245     86400   IN       PTR     supybot.buildbot.net.
-;246
-;247
-;248
-;249
-;250
-;251
-;252
-;253
-;254
+{% for name, ip in hosts_ips.items() %}
+{{ip}}     86400   IN       PTR     {{name}}.buildbot.net
+{% endfor %}

--- a/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
+++ b/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
@@ -1,5 +1,5 @@
 @       86400   IN      SOA     ns1.buildbot.net. hostmaster.buildbot.net. (
-                                        2016090201      ;serial
+                                        {{ dns_serial }}      ;serial
                                         10800           ;refresh
                                         1800            ;retry
                                         604800          ;expire

--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -1,6 +1,6 @@
 $TTL            86400
 @       86400   IN      SOA     ns1.buildbot.net. hostmaster.buildbot.net. (
-                                        2016090201      ;serial
+                                        2016091701      ;serial
                                         10800           ;refresh
                                         1800            ;retry
                                         604800          ;expire
@@ -13,47 +13,21 @@ $TTL            86400
 @               IN      NS      ns1.darkbeer.org.   ; usa
 @               IN      MX      10 mx.buildbot.net.
 @               IN      A       140.211.10.238
-buildbot        IN      A       140.211.10.239
-xy2dwhhhx5d4    IN      CNAME   gv-d47fzorbndt4i4.dv.googlehosted.com.
-mx              IN      A       140.211.10.235
-www             IN      A       140.211.10.238
-www-new         IN      A       140.211.10.238
-lists           IN      A       140.211.10.241
-trac            IN      A       140.211.10.240
-ftp             IN      A       140.211.10.243
-bot             IN      A       140.211.10.242
-service1        IN      A       140.211.10.230
-service2        IN      A       140.211.10.231
-service3        IN      A       140.211.10.232
-vm1             IN      A       140.211.10.233
-mac1            IN      A       140.211.10.234
-ns1             IN      A       140.211.10.236
-docs            IN      A       140.211.10.237
+
+{% for name, ip in hosts_ips.items() %}
+{{name}}              IN      A       {{external_network}}.{{ip}}
+{% endfor %}
+
 pr-docs         IN      CNAME   pr-docs.buildbot.net.s3-website-us-east-1.amazonaws.com.
 status          IN      CNAME   status.buildbot.net.s3-website-us-east-1.amazonaws.com.
-nine            IN      A       140.211.10.244
-supybot         IN      A       140.211.10.245
-events          IN      A       140.211.10.227
-prci            IN      A       209.177.87.210
+
 ; dont forget to update the serial in 3rd line when adding new records!
 
 ; Our "internal" addreses.  Note that we do not use split DNS. Also note that
 ; there is no reverse resolution for these addresses.
 
 $ORIGIN int.buildbot.net.
-backup          IN      A       192.168.80.212
-bslave1         IN      A       192.168.80.226
-buildbot        IN      A       192.168.80.239
-docs            IN      A       192.168.80.237
-mx              IN      A       192.168.80.235
-ns1             IN      A       192.168.80.236
-syslog          IN      A       192.168.80.211
-www             IN      A       192.168.80.238
-trac            IN      A       192.168.80.240
-lists           IN      A       192.168.80.241
-bot             IN      A       192.168.80.242
-ftp             IN      A       192.168.80.243
-nine            IN      A       192.168.80.244
-supybot         IN      A       192.168.80.245
-build1          IN      A       192.168.80.210
-events          IN      A       192.168.80.227
+
+{% for name, ip in hosts_ips.items() %}
+{{name}}              IN      A       {{internal_network}}.{{ip}}
+{% endfor %}

--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -1,6 +1,6 @@
 $TTL            86400
 @       86400   IN      SOA     ns1.buildbot.net. hostmaster.buildbot.net. (
-                                        2016091701      ;serial
+                                        {{ dns_serial }}      ;serial
                                         10800           ;refresh
                                         1800            ;retry
                                         604800          ;expire


### PR DESCRIPTION
necessary for syslog.buildbot.net to be available.

note that internal only jails are also visible, but their ip address is not mapped, so that is not a very big issue.
