### PR TITLE
fixes for prod:

### DIFF
--- a/roles/bb-master/tasks/main.yml
+++ b/roles/bb-master/tasks/main.yml
@@ -88,6 +88,15 @@
         content: "{{ hyper_keys }}"
       - filename: github_oauth.pass
         content: "{{ github_oauth_keys[ansible_hostname] }}"
+  tags: bb-master
+
+- name: Make sure we have latest raw creds
+  become_user: "{{ bb_user }}"
+  copy:
+    dest: "{{ bb_master_dir }}/{{ metabbotcfg_short }}/{{item.filename}}"
+    content: "{{ item.content }}"
+    mode: "0600"
+  with_items:
       - filename: github_token
         content: "{{ github_api_token }}"
   tags: bb-master

--- a/roles/elk/templates/oauth2_proxy.conf
+++ b/roles/elk/templates/oauth2_proxy.conf
@@ -15,6 +15,8 @@ email_domains = ['*']
 cookie_secret = "{{ github_oauth_keys[ansible_hostname]['clientsecret'] }}"
 {% if is_vagrant %}
 redirect_url = "https://{{ internal_ip }}/oauth2/callback"
+cookie_domain = "{{ internal_ip }}"
 {% else %}
 redirect_url = "https://{{ web_host_name }}/oauth2/callback"
+cookie_domain = "{{ web_host_name }}"
 {% endif %}


### PR DESCRIPTION
syslog: properly set the cookie the the right domain (instead of local_ip default)
bb-master: properly store the github_token (instead of storing in json format, quoted)