### PR TITLE
Use an empty default if no github oauth keys

### DIFF
--- a/roles/bb-master/tasks/main.yml
+++ b/roles/bb-master/tasks/main.yml
@@ -87,7 +87,7 @@
       - filename: hyper.pass
         content: "{{ hyper_keys }}"
       - filename: github_oauth.pass
-        content: "{{ github_oauth_keys[ansible_hostname] }}"
+        content: "{{ github_oauth_keys[ansible_hostname] | default({}) }}"
   tags: bb-master
 
 - name: Make sure we have latest raw creds


### PR DESCRIPTION
This should fix the undefined errors in the buildbot jail. The issue is that Ansible is trying to access `github_oauth_keys['buildbot']` but that key doesn't exist. I opted for creating an empty file.