### PR TITLE
discard modifications in git working directory

### DIFF
--- a/roles/simple-buildout/tasks/main.yml
+++ b/roles/simple-buildout/tasks/main.yml
@@ -7,6 +7,8 @@
     update: yes
     version: "{{ repo_branch }}"
     accept_hostkey: True
+    # discard all modified files in working directory
+    force: yes
   register: repo_state
   environment: "{{ proxy_env }}"
 


### PR DESCRIPTION
Currently Ansible fails with:

```
TASK [simple-buildout : Make sure we have an updated copy of the repository] ***
 [WARNING]: Using world-readable permissions for temporary files Ansible needs
to create when becoming an unprivileged user which may be insecure. For
information on securing this, see https://docs.ansible.com/ansible/become.html
#becoming-an-unprivileged-user
fatal: [localhost]: FAILED! => {"changed": false, "failed": true, "msg": "Local modifications exist in repository (force=no)."}
```

I assume there are somehow appeared changes in the working directory (maybe towncrier generated changelog in one of the previous builds).

With this PR changes in working directory will always be discarded.