### PR TITLE
increase supervisord stop timeout before it SIGKILLs

### DIFF
--- a/jail-nine.yml
+++ b/jail-nine.yml
@@ -42,6 +42,7 @@
     service_dir: "{{ getent_passwd[worker_account].4 }}/{{ master_dir }}"
     service_command: "{{ getent_passwd[worker_account].4 }}/{{ env_name }}/bin/buildbot start --nodaemon"
     service_user: "{{ worker_account }}"
+    service_stopwaitsecs:  300
   - role: nginx
     nginx_template: proxy
     server_name: "{{ web_host_name }}"

--- a/roles/supervisor-service/templates/service.conf.j2
+++ b/roles/supervisor-service/templates/service.conf.j2
@@ -21,7 +21,7 @@ environment={% for k, v in service_environment.items() %}{{k}}="{{v}}",{% endfor
 # [re]start behaviour
 autostart=true
 autorestart=true
-
+stopwaitsecs={{service_stopwaitsecs | default(10)}}
 # output handling
 redirect_stderr=true
 stdout_logfile={{supervisor_log_dir}}/{{service_name}}.log


### PR DESCRIPTION
the master takes more time now to finish cleanly, but if supervisor kills it it won't restart it