### PR TITLE
use clean shutdown to manage nine.bb.net CD

### DIFF
--- a/jail-nine.yml
+++ b/jail-nine.yml
@@ -42,7 +42,7 @@
     service_dir: "{{ getent_passwd[worker_account].4 }}/{{ master_dir }}"
     service_command: "{{ getent_passwd[worker_account].4 }}/{{ env_name }}/bin/buildbot start --nodaemon"
     service_user: "{{ worker_account }}"
-    service_stopwaitsecs:  {{ 40 * 60 }}  # our slowest build is 22 min. let's try hard to really not kill stuff
+    service_stopwaitsecs:  "{{ 40 * 60 }}"  # our slowest build is 22 min. let's try hard to really not kill stuff
     service_stopsignal: USR1   # sigusr1 is cleanshutdown (wait all builds to finish before stop)
   - role: nginx
     nginx_template: proxy

--- a/jail-nine.yml
+++ b/jail-nine.yml
@@ -42,7 +42,8 @@
     service_dir: "{{ getent_passwd[worker_account].4 }}/{{ master_dir }}"
     service_command: "{{ getent_passwd[worker_account].4 }}/{{ env_name }}/bin/buildbot start --nodaemon"
     service_user: "{{ worker_account }}"
-    service_stopwaitsecs:  300
+    service_stopwaitsecs:  {{ 40 * 60 }}  # our slowest build is 22 min. let's try hard to really not kill stuff
+    service_stopsignal: USR1   # sigusr1 is cleanshutdown (wait all builds to finish before stop)
   - role: nginx
     nginx_template: proxy
     server_name: "{{ web_host_name }}"

--- a/roles/supervisor-service/templates/service.conf.j2
+++ b/roles/supervisor-service/templates/service.conf.j2
@@ -22,6 +22,7 @@ environment={% for k, v in service_environment.items() %}{{k}}="{{v}}",{% endfor
 autostart=true
 autorestart=true
 stopwaitsecs={{service_stopwaitsecs | default(10)}}
+stopsignal={{service_stopsignal | default('TERM')}}
 # output handling
 redirect_stderr=true
 stdout_logfile={{supervisor_log_dir}}/{{service_name}}.log


### PR DESCRIPTION
Let's try doing nine.bb.net CD again, in a less disruptive way.