### PR TITLE
add direct access to elasticsearch

### DIFF
--- a/roles/elk/templates/oauth2_proxy.conf
+++ b/roles/elk/templates/oauth2_proxy.conf
@@ -6,9 +6,10 @@ provider = "github"
 github_org = "buildbot"
 github_team = "{{ github_team }}"
 
-http_address = "{{ internal_ip }}:{{ oauth2_proxy_port }}"
+http_address = "http://{{ internal_ip }}:{{ oauth2_proxy_port }}"
 upstreams = [
-    "http://{{ internal_ip }}:{{ kibana_port }}/"
+    "http://{{ internal_ip }}:{{ kibana_port }}/",
+    "http://{{ internal_ip }}:{{ logstash_port }}/logstash-*/"
 ]
 email_domains = ['*']
 


### PR DESCRIPTION
going through kibana proxy is much slower, so we change the conf
to allow direct access to elasticsearch