### PR TITLE
Fix vsftp TLS certificates

### DIFF
--- a/roles/vsftp/tasks/main.yml
+++ b/roles/vsftp/tasks/main.yml
@@ -12,25 +12,6 @@
     state: directory
   when: ssl
 
-- name: create ssl cert file
-  copy:
-    content: "{{ ssl_keys[server_name]['cert'] }}"
-    dest: "{{ ssl_cert_file }}"
-    mode: 0600
-    owner: root
-    group: wheel
-  notify: restart vsftpd
-  when: ssl
-
-- name: create ssl key file
-  copy:
-    content: "{{ ssl_keys[server_name]['key'] }}"
-    dest: "{{ ssl_key_file }}"
-    mode: 0600
-    owner: root
-    group: wheel
-  when: ssl
-
 - name: configure vsftpd
   template:
     src: vsftpd.conf.j2

--- a/roles/vsftp/templates/vsftpd.conf.j2
+++ b/roles/vsftp/templates/vsftpd.conf.j2
@@ -52,8 +52,8 @@ ssl_sslv3=NO
 require_ssl_reuse=NO
 ssl_ciphers=HIGH
 
-rsa_cert_file={{ ssl_cert_file }}
-rsa_private_key_file={{ ssl_key_file }}
+rsa_cert_file=/usr/local/etc/nginx/certs/ftp.buildbot.net.crt
+rsa_private_key_file=/usr/local/etc/nginx/certs/ftp.buildbot.net.key
 {% else %}
 ssl_enable=NO
 {% endif %}


### PR DESCRIPTION
Use the same certificate and key that nginx uses. This should stop the cron emails from the ftp jail.