### PR TITLE
Ignore "Permission denied" errors when clearing temp files

### DIFF
--- a/roles/base/templates/run-ansible-pull.sh.j2
+++ b/roles/base/templates/run-ansible-pull.sh.j2
@@ -56,6 +56,6 @@ if [ $RESULT -ne 0 ]; then
 fi
 
 # clean up temp files
-find /home/{{ service_account }}/.ansible/tmp -type d -mtime +1 -delete
+find /home/{{ service_account }}/.ansible/tmp -type d -mtime +1 -delete 2>&1 | grep -v 'Permission denied'
 
 rm -f "$OUTPUT"


### PR DESCRIPTION
The trac jail almost always complains about files that can't be deleted. The file list changes with every cron. Just filter them out completely.