### PR TITLE
Default authorized key to empty string and check it's not that

### DIFF
--- a/roles/user/defaults/main.yml
+++ b/roles/user/defaults/main.yml
@@ -1,4 +1,4 @@
 ---
 # set this to the text of a public key to allow that key to authenticate
 # as this user
-authorized_key:
+authorized_key: ''

--- a/roles/user/tasks/main.yml
+++ b/roles/user/tasks/main.yml
@@ -9,7 +9,7 @@
   authorized_key:
     user: "{{ user_id }}"
     key: "{{ authorized_key }}"
-  when: authorized_key
+  when: authorized_key != ''
 
 # NOTE: the information will only be available until the next use of `getent`
 - name: get user information


### PR DESCRIPTION
Some point after Ansible 2.1, the check changed and now a variable that has spaces in its value doesn't work. Explicitly compare against the empty string, and change the default to the empty string, to change the comparison to work.

Leaving the default value as nothing (e.g. "authorized_key:") has YAML use an empty dict as the value. Since the authorized_key is expected to be a string, use that as a default value.