### PR TITLE
move jails on service1 to service2

### DIFF
--- a/host-service1.yml
+++ b/host-service1.yml
@@ -4,18 +4,6 @@
   gather_facts: no
   connection: "{{ ansible_connection }}"
   become: yes
-  roles:
-  - role: jail
-    name: mx
-    hostname: mx.buildbot.net
-    internet_visible: true
-  - role: jail
-    name: ns1
-    hostname: ns1.buildbot.net
-    internet_visible: true
-  - role: jail
-    name: syslog
-    hostname: syslog.buildbot.net
-    internet_visible: true
+  roles: []
 
 # vim:ts=2:sw=2:noai:nosi

--- a/host-service2.yml
+++ b/host-service2.yml
@@ -6,6 +6,20 @@
   become: yes
   roles:
   - role: jail
+    name: mx
+    hostname: mx.buildbot.net
+    internet_visible: true
+  - role: jail
+    name: ns1
+    hostname: ns1.buildbot.net
+    internet_visible: true
+  - role: jail
+    name: syslog
+    hostname: syslog.buildbot.net
+    internet_visible: true
+  # note that the remainder here are specified the "old way", with
+  # ip_address
+  - role: jail
     name: bot
     hostname: bot.buildbot.net
     ip_address:


### PR DESCRIPTION
Note that these jails have their IPs specified in host_ips in
group_vars/all; the ip_address: .. format appears to be the old way,
previous to 90c8214ea54c251cbe073af49887f2859dc02e00.

Note, too, that this will lead to great sadness if service1 comes back up, as it will try to steal those IPs.  We will need to avoid that if the host ever does come back.