### PR TITLE
vim-lite renamed to vim-console

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -60,7 +60,7 @@ utility_packages:
   - bash
   - rsync
   - screen
-  - vim-lite
+  - vim-console
   Debian:
   - bash
   - rsync


### PR DESCRIPTION
maybe we should install the full vim?