### PR TITLE
elasticache is growing too big

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -10,6 +10,8 @@ ansible_python_interpreter: python2
 #
 # Note that SSH keys are in roles/base/files/authorized_keys
 #
+# Keep this in sync with the `buildbot-infra` team in Github.
+#
 # WARNING: do not remove entries from this list; just mark them 'state: absent'
 
 admin_users:

--- a/jail-syslog.yml
+++ b/jail-syslog.yml
@@ -10,4 +10,5 @@
     - role: elk
       logstash_variant: syslog
       server_name: "{{ web_host_name }}"
-      github_team: "core"  # this restricts access to only people in the github 'core' team
+      # this restricts access to only people in the github 'buildbot-infra' team
+      github_team: "buildbot-infra"


### PR DESCRIPTION
We ran out of space on service1, mostly in the syslog jail.  I deleted `/var/log/logstash.log`, which was 17G, and that helped a little.  I restarted logstash too.

However, the bigger consumer of space is `/var/db/elasticache`.  What can we do to limit the size of that db?