### PR TITLE
Bootstrap without SSH

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -21,9 +21,8 @@ Before running the script, ensure:
 * The basic system is installed (FreeBSD 10.0+) on the host
 * Networking for the host is fully configured
 * The hostname (uname -n) of the host is set correctly
-* The root password is known (or SSH keys set up)
-* Ssh access for 'root' is enabled (`PermitRootLogin yes`; note that this is not the default!)
 * You know the vault password
+* Run as root
 
 Development
 -----------

--- a/README.rst
+++ b/README.rst
@@ -15,7 +15,7 @@ Supply host-specific variables in ``group_vars/$hostname``.
 Bootstrapping
 -------------
 
-To bootstrap a newly-installed system, use ``./bootstrap HOSTNAME``.
+To bootstrap a newly-installed system, use ``./bootstrap``.
 Before running the script, ensure:
 
 * The basic system is installed (FreeBSD 10.0+) on the host

--- a/bootstrap
+++ b/bootstrap
@@ -3,23 +3,10 @@
 # This script sets up a brand-new FreeBSD host as the proper piece of Buildbot
 # infrastructure.  See README.rst
 #
-# Usage: ./bootstrap HOST
+# Usage: ./bootstrap
 
 set -e
 
-HOSTNAME="${1}"
-if [ -z "${HOSTNAME}" ]; then
-    echo "USAGE: ./bootstrap hostname"
-    exit 1
-fi
+env ASSUME_ALWAYS_YES=YES pkg install ansible git
 
-SSH_ARGS="$SSH_ARGS -o PreferredAuthentications=password,keyboard-interactive"
-# don't prompt to add the SSH key
-SSH_ARGS="$SSH_ARGS -o StrictHostKeyChecking=no"
-# use a control connection to send multiple SSH commands through a single connection
-SSH_ARGS="$SSH_ARGS -o ControlPersist=10m"
-SSH_ARGS="$SSH_ARGS -o ControlMaster=auto"
-
-export ANSIBLE_SSH_ARGS="$SSH_ARGS"
-
-ansible-playbook --ask-vault-pass -e target_host=${HOSTNAME} bootstrap.yml
+ansible-pull -U https://github.com/buildbot/buildbot-infra --ask-vault-pass local.yml

--- a/bootstrap
+++ b/bootstrap
@@ -7,6 +7,6 @@
 
 set -e
 
-env ASSUME_ALWAYS_YES=YES pkg install ansible git
+env ASSUME_ALWAYS_YES=YES pkg install ansible git python2
 
 ansible-pull -U https://github.com/buildbot/buildbot-infra --ask-vault-pass local.yml

--- a/bootstrap
+++ b/bootstrap
@@ -9,4 +9,4 @@ set -e
 
 env ASSUME_ALWAYS_YES=YES pkg install ansible git python2
 
-ansible-pull -U https://github.com/buildbot/buildbot-infra --ask-vault-pass local.yml
+ansible-playbook --ask-vault-pass local.yml

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -15,8 +15,7 @@
 
 - name: bootstrap remote server
   hosts: new_host
-  connection: ssh
-  remote_user: root
+  connection: local
   gather_facts: no
   vars:
     # Fortunately, '/root' always exists.  This variable is used to prevent

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -1,20 +1,8 @@
 ---
-- name: prepare temporary group
-  hosts: all
-  gather_facts: no
-  connection: local
-
-  tasks:
-  - name: create temporary group for the target host
-    add_host:
-      hostname: "{{ target_host }}"
-      groupname: new_host
-
 # Needs to be performed here, so the secrets are available for the new group
 - include: "load-secrets.yml"
 
 - name: bootstrap remote server
-  hosts: new_host
   connection: local
   gather_facts: no
   vars:
@@ -23,11 +11,6 @@
     bootstrap_script: "/root/run-once"
 
   tasks:
-  # There's an overlap here with run-once script.  I (sa2ajj) could not think
-  # of any "nicer" way though.
-  - name: install ansible
-    raw: "env ASSUME_ALWAYS_YES=YES pkg install ansible"
-
   - name: prepare bootstrap script
     template:
       src: "templates/run-once"

--- a/templates/run-once
+++ b/templates/run-once
@@ -17,7 +17,7 @@ cd ~
 env ASSUME_ALWAYS_YES=YES pkg install ansible git sudo
 
 # vagrant build will not use ansible pull on the jails (as it is better to just update on demand each jail)
-{% if is_vagrant %}
+{% if is_vagrant|default(False) %}
 # bootstrap access for vagrant user
 if [ ! -d /home/vagrant ]
 then


### PR DESCRIPTION
Don't require connecting via SSH to allow weak root password combined with not permitting remote root login.