### PR TITLE
Remove Jinja2 templating from when statements

### DIFF
--- a/roles/base/tasks/ansible-pull.yml
+++ b/roles/base/tasks/ansible-pull.yml
@@ -3,14 +3,14 @@
   pkgng:
     name: ansible
     state: present
-  when: '{{ ansible_distribution == "FreeBSD" }}'
+  when: ansible_distribution == "FreeBSD"
   environment: "{{ proxy_env }}"
 
 - name: install ansible (Debian)
   apt:
     name: ansible
     state: present
-  when: '{{ ansible_distribution == "Debian" }}'
+  when: ansible_distribution == "Debian"
 
 - name: create wheel group
   group:

--- a/roles/base/tasks/packages.yml
+++ b/roles/base/tasks/packages.yml
@@ -3,7 +3,7 @@
     name: "{{item}}"
     state: present
   with_items: "{{ mandatory_packages[ansible_distribution] }}"
-  when: '{{ ansible_distribution == "FreeBSD" }}'
+  when: ansible_distribution == "FreeBSD"
   environment: "{{ proxy_env }}"
 
 - name: install utility packages (FreeBSD)
@@ -11,7 +11,7 @@
     name: "{{item}}"
     state: present
   with_items: "{{ utility_packages[ansible_distribution] }}"
-  when: '{{ ansible_distribution == "FreeBSD" }}'
+  when: ansible_distribution == "FreeBSD"
   environment: "{{ proxy_env }}"
 
 - name: install mandatory packages (Debian)
@@ -19,7 +19,7 @@
     name: "{{item}}"
     state: present
   with_items: "{{ mandatory_packages[ansible_distribution] }}"
-  when: '{{ ansible_distribution == "Debian" }}'
+  when: ansible_distribution == "Debian"
   environment: "{{ proxy_env }}"
 
 - name: install utility packages (Debian)
@@ -27,5 +27,5 @@
     name: "{{item}}"
     state: present
   with_items: "{{ utility_packages[ansible_distribution] }}"
-  when: '{{ ansible_distribution == "Debian" }}'
+  when: ansible_distribution == "Debian"
   environment: "{{ proxy_env }}"


### PR DESCRIPTION
This fixes a warning from Ansible:

     [WARNING]: when statements should not include jinja2 templating delimiters such as {{ }} or {% %}. Found: {{ ansible_distribution == "FreeBSD" }}