### PR TITLE
Disable recursion in Bind.  This was requested by an OSL scanner.

### DIFF
--- a/roles/dns/templates/named.conf
+++ b/roles/dns/templates/named.conf
@@ -10,6 +10,7 @@
 // * named.conf.zones -- all zone definitions (except for RFC related ones)
 
 options {
+    recursion no;
     include "{{ namedb_dir }}/named.conf.options";
 };
 


### PR DESCRIPTION
We need to make sure we copy the old configs to the new Ansible setup when
service1 is back online.