### PR TITLE
Update remote bootstrap to not require root login

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,13 +16,14 @@ Bootstrapping
 -------------
 
 To bootstrap a newly-installed system, use ``./bootstrap HOSTNAME``.
+Default is to log in to the remote system using your current username.
+To change the remote login, use ``./bootstrap HOSTNAME USERNAME``.
 Before running the script, ensure:
 
 * The basic system is installed (FreeBSD 10.0+) on the host
 * Networking for the host is fully configured
 * The hostname (uname -n) of the host is set correctly
-* The root password is known (or SSH keys set up)
-* Ssh access for 'root' is enabled (`PermitRootLogin yes`; note that this is not the default!)
+* Sudo configured for a non-root user to become root
 * You know the vault password
 
 Development

--- a/bootstrap
+++ b/bootstrap
@@ -8,12 +8,12 @@
 set -e
 
 HOSTNAME="${1}"
+REMOTE_USER=${2:-$USER}
 if [ -z "${HOSTNAME}" ]; then
-    echo "USAGE: ./bootstrap hostname"
+    echo "USAGE: ./bootstrap hostname [remote-user]"
     exit 1
 fi
 
-SSH_ARGS="$SSH_ARGS -o PreferredAuthentications=password,keyboard-interactive"
 # don't prompt to add the SSH key
 SSH_ARGS="$SSH_ARGS -o StrictHostKeyChecking=no"
 # use a control connection to send multiple SSH commands through a single connection
@@ -22,4 +22,7 @@ SSH_ARGS="$SSH_ARGS -o ControlMaster=auto"
 
 export ANSIBLE_SSH_ARGS="$SSH_ARGS"
 
-ansible-playbook --ask-vault-pass -e target_host=${HOSTNAME} bootstrap.yml
+ansible-playbook --ask-vault-pass \
+    -e target_user=$REMOTE_USER \
+    -e target_host=${HOSTNAME} \
+    bootstrap.yml

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -29,7 +29,7 @@
   # There's an overlap here with run-once script.  I (sa2ajj) could not think
   # of any "nicer" way though.
   - name: install ansible
-    raw: "pkg install --yes {{ pkg_ansible_version }}"
+    raw: "pkg install --yes python2 {{ pkg_ansible_version }}"
 
   - name: prepare bootstrap script
     template:

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -16,7 +16,9 @@
 - name: bootstrap remote server
   hosts: new_host
   connection: ssh
-  remote_user: root
+  remote_user: "{{ target_user }}"
+  become: yes
+  become_user: root
   gather_facts: no
   vars:
     # Fortunately, '/root' always exists.  This variable is used to prevent

--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -29,7 +29,7 @@
   # There's an overlap here with run-once script.  I (sa2ajj) could not think
   # of any "nicer" way though.
   - name: install ansible
-    raw: "env ASSUME_ALWAYS_YES=YES pkg install {{ pkg_ansible_version }}"
+    raw: "pkg install --yes {{ pkg_ansible_version }}"
 
   - name: prepare bootstrap script
     template:

--- a/group_vars/all
+++ b/group_vars/all
@@ -179,3 +179,6 @@ hosts_ips:
 
 # vars are lazily evaluated so ansible_hostname will be valid at the time of evaluation (via gatherfacts)
 internal_ip: "{{ internal_network }}.{{ hosts_ips[ansible_hostname] }}"
+
+# Default is not using Vagrant. It will be overriden in vagrant.yml.
+is_vagrant: false

--- a/templates/run-once
+++ b/templates/run-once
@@ -19,10 +19,9 @@ pkg install --yes {{ pkg_ansible_version }} git sudo
 # vagrant build will not use ansible pull on the jails (as it is better to just update on demand each jail)
 {% if is_vagrant %}
 # bootstrap access for vagrant user
-if [ ! -d /home/vagrant ]
-then
-pw useradd -n vagrant -s /bin/sh -m -G wheel
-echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /usr/local/etc/sudoers
+if [ ! -d /home/vagrant ]; then
+    pw useradd -n vagrant -s /bin/sh -m -G wheel
+    echo '%wheel ALL=(ALL) NOPASSWD: ALL' >> /usr/local/etc/sudoers
 fi
 # root ssh keys is copied at the jail setup, and must be copied to this user
 cp -rf /root/.ssh /home/vagrant

--- a/templates/run-once
+++ b/templates/run-once
@@ -14,7 +14,7 @@ repo_dir=repo
 cd ~
 
 # Install prerequsite packages
-env ASSUME_ALWAYS_YES=YES pkg install {{ pkg_ansible_version }} git sudo
+pkg install --yes {{ pkg_ansible_version }} git sudo
 
 # vagrant build will not use ansible pull on the jails (as it is better to just update on demand each jail)
 {% if is_vagrant %}


### PR DESCRIPTION
Previous method required root login. Changed that to use a non-root user with sudo, matching how logins are done on Buildbot systems.

Also updated packages that need to be installed. The `ansible` package no longer exists; it's been replaced with versioned packages. The `python2` package needs to be installed to so `ansible_python_interpreter` points to a valid executable.