### PR TITLE
Include trailing `.` in reverse DNS, fix www -> buildbot.net

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -149,7 +149,7 @@ internal_if: vlan0
 external_if: lagg0
 
 # needs to be changed each time the dns config is updated
-dns_serial: 2016091701  # YYYYMMDD01
+dns_serial: 2019021701  # YYYYMMDD01
 
 # IP addresses for all hosts in the network
 hosts_ips:

--- a/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
+++ b/roles/dns/templates/224-255.128-255.10.211.140.in-addr.arpa
@@ -10,5 +10,9 @@
 @               7200    IN      NS      ns1.darkbeer.org.   ; usa
 
 {% for name, ip in hosts_ips.items() %}
-{{ip}}     86400   IN       PTR     {{name}}.buildbot.net
+{% if name == "www" -%}
+{{ip}      86400   IN       PTR     buildbot.net.
+{% else -%}
+{{ip}}     86400   IN       PTR     {{name}}.buildbot.net.
+{% endif -%}
 {% endfor %}

--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -15,7 +15,11 @@ $TTL            86400
 @               IN      A       140.211.10.238
 
 {% for name, ip in hosts_ips.items() %}
+{% if name == "www" -%}
+{{name}}              IN      CNAME   buildbot.net.
+{% else -%}
 {{name}}              IN      A       {{external_network}}.{{ip}}
+{% endif -%}
 {% endfor %}
 
 pr-docs         IN      CNAME   pr-docs.buildbot.net.s3-website-us-east-1.amazonaws.com.


### PR DESCRIPTION
This includes conditionals so that forward/reverse for the www jail is
treated as `buildbot.net`, with `www` being a CNAME for that.

References #220 (and hopefully fixes?)