### PR TITLE
Add DKIM support

### DIFF
--- a/group_vars/all
+++ b/group_vars/all
@@ -149,7 +149,7 @@ internal_if: vlan0
 external_if: lagg0
 
 # needs to be changed each time the dns config is updated
-dns_serial: 2019021701  # YYYYMMDD01
+dns_serial: 2019022101  # YYYYMMDD01
 
 # IP addresses for all hosts in the network
 hosts_ips:

--- a/roles/dns/templates/buildbot.net
+++ b/roles/dns/templates/buildbot.net
@@ -14,6 +14,11 @@ $TTL            86400
 @               IN      MX      10 mx.buildbot.net.
 @               IN      A       140.211.10.238
 
+mail._domainkey       IN      TXT     ( "v=DKIM1; h=rsa-sha256; k=rsa; s=email; "
+          "p=MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAolCoI83GECBEUCEXswQaMbf+n8ORtxpbyHwQh+7nSpzFPkO6yJrNhfFcUwYn83njd+cLkVphUlKsjsC/NfPWenVifDfJP1BH7V/D6gwZr3aTJRUc1uFNyq5N0clKhy/tuyHUTsyYmAGTnn9uqr8gLhLJr7SV88I0GnLychEadaGuwefyqTOrIyp4s6vQjJK8edfDISjA5W3ZNv"
+          "5RrZ9jcdPdbCng9r5GpIPth5K0nu196lEMoOf8Twy0NVQ9Oe/aKyS/aym0n1uI0Y9s13PanMQf9YD9QJGcziFuuKt0VpgiMHMKRLDvReQGjtRMBk3h09t3fPYNWketVgh4PrJasQIDAQAB" )  ; ----- DKIM key 201901 for buildbot.net
+
+
 {% for name, ip in hosts_ips.items() %}
 {% if name == "www" -%}
 {{name}}              IN      CNAME   buildbot.net.


### PR DESCRIPTION
Refs #220.  @verm implemented this directly on the host and Ansible happily reverted it, so it is no longer in place.

I think this is associated with some changes on mx as well.  It doesn't look like Ansible has reverted those.  Below I've included the changes captured by `git log`.  @verm can you help us figure out what we need to change in Ansible, or should we just reverse-engineer this?  Also, we should probably erase and rebuild the mx jail once we've put this in Ansible, to make sure we are not accidentally relying on a manual modification that wasn't captured here.

```patch
root@mx /etc # git show HEAD
commit 8a381fa99992d479a4a158a80209e9bc908de3c9 (HEAD -> master)
Author: Unknown <sysadmin@buildbot.net>
Date:   Tue Feb 19 16:15:47 2019 +0000
    
    safe

diff --git a/rc.conf b/rc.conf
index 1386eba..b33e7c2 100644
--- a/rc.conf
+++ b/rc.conf
@@ -8,3 +8,7 @@ sendmail_outbound_enable="NO"
 sendmail_msp_queue_enable="NO"
 sshd_enable="NO"
 postfix_enable="YES"
+
+milteropendkim_enable="YES"
+milteropendkim_uid="opendkim"
+
```

and in /usr/local/etc:
```patch
diff --git a/mail/opendkim.conf b/mail/opendkim.conf
new file mode 100644
index 0000000..b4a7c79
--- /dev/null
+++ b/mail/opendkim.conf
@@ -0,0 +1,789 @@
+##
+## opendkim.conf -- configuration file for OpenDKIM filter
+##
+## Copyright (c) 2010-2015, The Trusted Domain Project.  All rights reserved.
+##
+
+##
+## For settings that refer to a "dataset", see the opendkim(8) man page.
+##
+
+## DEPRECATED CONFIGURATION OPTIONS
+## 
+## The following configuration options are no longer valid.  They should be
+## removed from your existing configuration file to prevent potential issues.
+## Failure to do so may result in opendkim being unable to start.
+## 
+## Removed in 2.10.0:
+##   AddAllSignatureResults
+##   ADSPAction
+##   ADSPNoSuchDomain
+##   BogusPolicy
+##   DisableADSP
+##   LDAPSoftStart
+##   LocalADSP
+##   NoDiscardableMailTo
+##   On-PolicyError
+##   SendADSPReports
+##   UnprotectedPolicy
+
+## CONFIGURATION OPTIONS
+
+##  AllowSHA1Only { yes | no }
+##     default "no"
+##
+##  By default, the filter will refuse to start if support for SHA256 is
+##  not available since this violates the strong recommendations of
+##  RFC6376 Section 3.3, which says:
+##
+##  "Verifiers MUST implement both rsa-sha1 and rsa-sha256.  Signers MUST
+##   implement and SHOULD sign using rsa-sha256."
+##
+##  This forces that violation to be explicitly selected by the administrator.
+
+# AllowSHA1Only                no
+
+##  AlwaysAddARHeader { yes | no }
+##     default "no"
+##
+##  Add an "Authentication-Results:" header even to unsigned messages
+##  from domains with no "signs all" policy.  The reported DKIM result
+##  will be "none" in such cases.  Normally unsigned mail from non-strict
+##  domains does not cause the results header to be added.
+
+# AlwaysAddARHeader    no
+
+##  AuthservID string
+##     default (local host name)
+##
+##  Defines the "authserv-id" token to be used when generating 
+##  Authentication-Results headers after message verification.
+
+# AuthservID           example.com
+
+##  AuthservIDWithJobID
+##     default "no"
+##
+##  Appends a "/" followed by the MTA's job ID to the "authserv-id" token
+##  when generating Authentication-Results headers after message verification.
+
+# AuthservIDWithJobId  no
+
+##  AutoRestart { yes | no }
+##     default "no"
+##
+##  Indicate whether or not the filter should arrange to restart automatically
+##  if it crashes.
+
+# AutoRestart          No
+
+##  AutoRestartCount n
+##     default 0
+##
+##  Sets the maximum automatic restart count.  After this number of
+##  automatic restarts, the filter will give up and terminate.  A value of 0
+##  implies no limit.
+
+# AutoRestartCount     0
+
+##  AutoRestartRate n/t[u]
+##     default (none)
+## 
+##  Sets the maximum automatic restart rate.  See the opendkim.conf(5)
+##  man page for the format of this parameter.
+
+# AutoRestartRate      n/tu
+
+##  Background { yes | no }
+##     default "yes"
+##
+##  Indicate whether or not the filter should run in the background.
+
+# Background           Yes
+
+##  BaseDirectory path
+##     default (none)
+##
+##  Causes the filter to change to the named directory before beginning
+##  operation.  Thus, cores will be dumped here and configuration files
+##  are read relative to this location.
+
+# BaseDirectory                /var/run/opendkim
+
+##  BodyLengthDB dataset
+##     default (none)
+##
+##  A data set that is checked against envelope recipients to see if a
+##  body length tag should be included in the generated signature.
+##  This has security implications; see opendkim.conf(5) for details.
+
+# BodyLengthDB         dataset
+
+##  Canonicalization hdrcanon[/bodycanon]
+##     default "simple/simple"
+##
+##  Select canonicalizations to use when signing.  If the "bodycanon" is
+##  omitted, "simple" is used.  Valid values for each are "simple" and
+##  "relaxed".
+
+# Canonicalization     simple/simple
+
+##  ClockDrift n
+##     default 300
+##
+##  Specify the tolerance range for expired signatures or signatures
+##  which appear to have timestamps in the future, allowing for clock
+##  drift.
+
+# ClockDrift           300 
+
+##  Diagnostics { yes | no }
+##     default "no"
+##
+##  Specifies whether or not signatures with header diagnostic tags should
+##  be generated.
+
+##  DNSTimeout n
+##     default 10
+##
+##  Specify the time in seconds to wait for replies from the nameserver when
+##  requesting keys or signing policies.
+
+# DNSTimeout           10
+
+##  Domain dataset
+##     default (none)
+##
+##  Specify for which domain(s) signing should be done.  No default; must
+##  be specified for signing.
+
+Domain                 example.com
+
+##  DomainKeysCompat { yes | no }
+##     default "no"
+##
+##  When enabled, backward compatibility with DomainKeys (RFC4870) key
+##  records is enabled.  Otherwise, such key records are considered to be
+##  syntactically invalid.
+
+# DomainKeysCompat     no
+
+##  DontSignMailTo     dataset
+##     default (none)
+##
+##  Gives a list of recipient addresses or address patterns whose mail should
+##  not be signed.
+
+# DontSignMailTo       addr1,addr2,...
+
+##  EnableCoredumps { yes | no }
+##     default "no"
+##
+##  On systems which have support for such, requests that the kernel dump
+##  core even though the process may change user ID during its execution.
+
+# EnableCoredumps      no
+
+##  ExemptDomains dataset
+##     default (none)
+##
+##  A data set of domain names that are checked against the message sender's
+##  domain.  If a match is found, the message is ignored by the filter.
+
+# ExemptDomains                domain1,domain2,...
+
+##  ExternalIgnoreList filename
+##
+##  Names a file from which a list of externally-trusted hosts is read.
+##  These are hosts which are allowed to send mail through you for signing.
+##  Automatically contains 127.0.0.1.  See man page for file format.
+
+# ExternalIgnoreList   filename
+
+##  FixCRLF { yes | no }
+##
+##  Requests that the library convert "naked" CR and LF characters to
+##  CRLFs during canonicalization.  The default is "no".
+
+# FixCRLF              no
+
+##  IgnoreMalformedMail { yes | no }
+##     default "no"
+##
+##  Silently passes malformed messages without alteration.  This includes 
+##  messages that fail the RequiredHeaders check, if enabled.  The default is
+##  to pass those messages but add an Authentication-Results field indicating
+##  that they were malformed.
+
+# IgnoreMalformedMail  no
+
+##  InternalHosts dataset
+##     default "127.0.0.1"
+##
+##  Names a file from which a list of internal hosts is read.  These are
+##  hosts from which mail should be signed rather than verified.
+##  Automatically contains 127.0.0.1.
+
+# InternalHosts                dataset
+
+##  KeepTemporaryFiles { yes | no }
+##     default "no"
+##
+##  If set, causes temporary files generated during message signing or
+##  verifying to be left behind for debugging use.  Not for normal operation;
+##  can fill your disks quite fast on busy systems.
+
+# KeepTemporaryFiles   no
+
+##  KeyFile filename
+##     default (none)
+##
+##  Specifies the path to the private key to use when signing.  Ignored if
+##  SigningTable and KeyTable are used.  No default; must be specified for 
+##  signing if SigningTable/KeyTable are not in use.
+
+KeyFile                        /var/db/dkim/example.private
+
+##  KeyTable dataset
+##     default (none)
+##
+##  Defines a table that will be queried to convert key names to
+##  sets of data of the form (signing domain, signing selector, private key).
+##  The private key can either contain a PEM-formatted private key,
+##  a base64-encoded DER format private key, or a path to a file containing
+##  one of those.
+
+# KeyTable             dataset
+
+##  LogWhy { yes | no }
+##     default "no"
+##
+##  If logging is enabled (see Syslog below), issues very detailed logging
+##  about the logic behind the filter's decision to either sign a message
+##  or verify it.  The logic behind the decision is non-trivial and can be
+##  confusing to administrators not familiar with its operation.  A
+##  description of how the decision is made can be found in the OPERATIONS
+##  section of the opendkim(8) man page.  This causes a large increase
+##  in the amount of log data generated for each message, so it should be
+##  limited to debugging use and not enabled for general operation.
+
+# LogWhy               no
+
+##  MacroList macro[=value][,...]
+##
+##  Gives a set of MTA-provided macros which should be checked to see
+##  if the sender has been determined to be a local user and therefore
+##  whether or not signing should be done.  See opendkim.conf(5) for
+##  more information.
+
+# MacroList            foo=bar,baz=blivit
+
+##  MaximumHeaders n
+##
+##  Disallow messages whose header blocks are bigger than "n" bytes.
+##  Intended to detect and block a denial-of-service attack.  The default
+##  is 65536.  A value of 0 disables this test.
+
+# MaximumHeaders       n
+
+##  MaximumSignaturesToVerify n
+##     (default 3)
+##
+##  Verify no more than "n" signatures on an arriving message.
+##  A value of 0 means "no limit".
+
+# MaximumSignaturesToVerify    n
+
+##  MaximumSignedBytes n
+##
+##  Don't sign more than "n" bytes of the message.  The default is to 
+##  sign the entire message.  Setting this implies "BodyLengths".
+
+# MaximumSignedBytes   n
+
+##  MilterDebug n
+##
+##  Request a debug level of "n" from the milter library.  The default is 0.
+
+# MilterDebug          0
+
+##  Minimum n[% | +]
+##     default 0
+##
+##  Sets a minimum signing volume; one of the following formats:
+##     n       at least n bytes (or the whole message, whichever is less)
+##             must be signed
+##     n%      at least n% of the message must be signed
+##     n+      if a length limit was presented in the signature, no more than
+##             n bytes may have been added
+
+# Minimum              n
+
+##  MinimumKeyBits n
+##     default 1024
+##
+##  Causes the library not to accept signatures matching keys made of fewer
+##  than the specified number of bits, even if they would otherwise pass
+##  DKIM signing.
+
+# MinimumKeyBits       1024
+
+##  Mode [sv]
+##     default sv
+##
+##  Indicates which mode(s) of operation should be provided.  "s" means
+##  "sign", "v" means "verify".
+
+# Mode                 sv
+
+##  MTA dataset
+##     default (none)
+##  
+##  Specifies a list of MTAs whos mail should always be signed rather than
+##  verified.  The "mtaname" is extracted from the DaemonPortOptions line
+##  in effect.
+
+# MTA                  name
+
+##  MultipleSignatures { yes | no }
+##     default no
+##
+##  Allows multiple signatures to be added.  If set to "true" and a SigningTable
+##  is in use, all SigningTable entries that match the candidate message will
+##  cause a signature to be added.  Otherwise, only the first matching
+##  SigningTable entry will be added, or only the key defined by Domain,
+##  Selector and KeyFile will be added.
+
+# MultipleSignatures   no
+
+##  MustBeSigned dataset
+##     default (none)
+##
+##  Defines a list of headers which, if present on a message, must be
+##  signed for the signature to be considered acceptable.
+
+# MustBeSigned         header1,header2,...
+
+##  Nameservers addr1[,addr2[,...]]
+##     default (none)
+##
+##  Provides a comma-separated list of IP addresses that are to be used when
+##  doing DNS queries to retrieve DKIM keys, VBR records, etc.
+##  These override any local defaults built in to the resolver in use, which
+##  may be defined in /etc/resolv.conf or hard-coded into the software.
+
+# Nameservers addr1,addr2,...
+
+##  NoHeaderB { yes | no }
+##     default "no"
+##
+##  Suppresses addition of "header.b" tags on Authentication-Results
+##  header fields.
+
+# NoHeaderB            no
+
+##  OmitHeaders dataset
+##     default (none)
+##
+##  Specifies a list of headers that should always be omitted when signing.
+##  Header names should be separated by commas.
+
+# OmitHeaders          header1,header2,...
+
+##  On-...
+##
+##  Specifies what to do when certain error conditions are encountered.
+##
+##  See opendkim.conf(5) for more information.
+
+# On-Default
+# On-BadSignature
+# On-DNSError
+# On-InternalError
+# On-NoSignature
+# On-Security
+# On-SignatureError
+
+##  OversignHeaders dataset
+##     default (none)
+##
+##  Specifies a set of header fields that should be included in all signature
+##  header lists (the "h=" tag) once more than the number of times they were
+##  actually present in the signed message.  See opendkim.conf(5) for more
+##  information.
+
+# OverSignHeaders      header1,header2,...
+
+##  PeerList dataset
+##     default (none)
+##
+##  Contains a list of IP addresses, CIDR blocks, hostnames or domain names
+##  whose mail should be neither signed nor verified by this filter.  See man
+##  page for file format.
+
+# PeerList             filename
+
+##  PidFile filename
+##     default (none)
+## 
+##  Name of the file where the filter should write its pid before beginning
+##  normal operations.
+
+# PidFile              filename
+
+##  POPDBFile dataset
+##     default (none)
+##
+##  Names a database which should be checked for "POP before SMTP" records
+##  as a form of authentication of users who may be sending mail through
+##  the MTA for signing.  Requires special compilation of the filter.
+##  See opendkim.conf(5) for more information.
+
+# POPDBFile            filename
+
+##  Quarantine { yes | no }
+##     default "no"
+##
+##  Indicates whether or not the filter should arrange to quarantine mail
+##  which fails verification.  Intended for diagnostic use only.
+
+# Quarantine           No
+
+##  QueryCache { yes | no }
+##     default "no"
+##
+##  Instructs the DKIM library to maintain its own local cache of keys and
+##  policies retrieved from DNS, rather than relying on the nameserver for
+##  caching service.  Useful if the nameserver being used by the filter is
+##  not local.  The filter must be compiled with the QUERY_CACHE flag to enable
+##  this feature, since it adds a library dependency.
+
+# QueryCache           No
+
+##  RedirectFailuresTo address
+##     default (none)
+##
+##  Redirects signed messages to the specified address if none of the
+##  signatures present failed to verify.
+
+# RedirectFailuresTo   postmaster@example.com
+
+##  RemoveARAll { yes | no }
+##     default "no"
+##
+##  Remove all Authentication-Results: headers on all arriving mail.
+
+# RemoveARAll          No
+
+##  RemoveARFrom dataset
+##     default (none)
+##
+##  Remove all Authentication-Results: headers on all arriving mail that
+##  claim to have been added by hosts listed in this parameter.  The list
+##  should be comma-separated.  Entire domains may be specified by preceding
+##  the dopmain name by a single dot (".") character.
+
+# RemoveARFrom         host1,host2,.domain1,.domain2,...
+
+##  RemoveOldSignatures { yes | no }
+##     default "no"
+##
+##  Remove old signatures on messages, if any, when generating a signature.
+
+# RemoveOldSignatures  No
+
+##  ReportAddress addr
+##     default (executing user)@(hostname)
+##
+##  Specifies the sending address to be used on From: headers of outgoing
+##  failure reports.  By default, the e-mail address of the user executing
+##  the filter is used.
+
+# ReportAddress                "DKIM Error Postmaster" <postmaster@example.com>
+
+##  ReportBccAddress addr
+##     default (none)
+##
+##  Specifies additional recipient address(es) to receive outgoing failure
+##  reports.
+
+# ReportBccAddress     postmaster@example.com, john@example.com
+
+##  RequiredHeaders { yes | no }
+##     default no
+##
+##  Rejects messages which don't conform to RFC5322 header count requirements.
+
+# RequiredHeaders      No
+
+##  RequireSafeKeys { yes | no }
+##     default yes
+##
+##  Refuses to use key files that appear to have unsafe permissions.
+
+# RequireSafeKeys      Yes
+
+##  ResignAll { yes | no }
+##     default no
+##
+##  Where ResignMailTo triggers a re-signing action, this flag indicates
+##  whether or not all mail should be signed (if set) versus only verified
+##  mail being signed (if not set).
+
+# ResignAll            No
+
+##  ResignMailTo dataset
+##     default (none)
+##
+##  Checks each message recipient against the specified dataset for a
+##  matching record.  The full address is checked in each case, then the
+##  hostname, then each domain preceded by ".".  If there is a match, the
+##  value returned is presumed to be the name of a key in the KeyTable
+##  (if defined) to be used to re-sign the message in addition to
+##  verifying it.  If there is a match without a KeyTable, the default key
+##  is applied.
+
+# ResignMailTo         dataset
+
+##  ResolverConfiguration string
+##
+##  Passes arbitrary configuration data to the resolver.  For the stock UNIX
+##  resolver, this is ignored; for Unbound, it names a resolv.conf(5)-style
+##  file that should be read for configuration information.
+
+# ResolverConfiguration        string
+
+##  ResolverTracing { yes | no }
+##
+##  Requests enabling of resolver trace features, if available.  The effect
+##  of setting this flag depends on how trace features, if any, are implemented
+##  in the resolver in use.  Currently only effective when used with the
+##  OpenDKIM asynchronous resolver.
+
+# ResolverTracing      no
+
+##  Selector name
+##
+##  The name of the selector to use when signing.  No default; must be
+##  specified for signing.
+
+Selector               my-selector-name
+
+##  SenderHeaders      dataset
+##     default (none)
+##
+##  Overrides the default list of headers that will be used to determine
+##  the sending domain when deciding whether to sign the message and with
+##  with which key(s).  See opendkim.conf(5) for details.
+
+# SenderHeaders                From
+
+##  SendReports { yes | no }
+##     default "no"
+##
+##  Specifies whether or not the filter should generate report mail back
+##  to senders when verification fails and an address for such a purpose
+##  is provided.  See opendkim.conf(5) for details.
+
+# SendReports          No
+
+##  SignatureAlgorithm signalg
+##     default "rsa-sha256"
+##
+##  Signature algorithm to use when generating signatures.  Must be either
+##  "rsa-sha1" or "rsa-sha256".
+
+# SignatureAlgorithm   rsa-sha256
+
+##  SignatureTTL seconds
+##     default "0"
+##
+##  Specifies the lifetime in seconds of signatures generated by the
+##  filter.  A value of 0 means no expiration time is included in the
+##  signature.
+
+# SignatureTTL         0
+
+##  SignHeaders dataset
+##     default (none)
+##
+##  Specifies the list of headers which should be included when generating
+##  signatures.  The string should be a comma-separated list of header names.
+##  See the opendkim.conf(5) man page for more information.
+
+# SignHeaders          header1,header2,...
+
+##  SigningTable dataset
+##     default (none)
+##
+##  Defines a dataset that will be queried for the message sender's address
+##  to determine which private key(s) (if any) should be used to sign the
+##  message.  The sender is determined from the value of the sender
+##  header fields as described with SenderHeaders above.  The key for this
+##  lookup should be an address or address pattern that matches senders;
+##  see the opendkim.conf(5) man page for more information.  The value
+##  of the lookup should return the name of a key found in the KeyTable
+##  that should be used to sign the message.  If MultipleSignatures
+##  is set, all possible lookup keys will be attempted which may result
+##  in multiple signatures being applied.
+
+# SigningTable         filename
+
+##  SingleAuthResult { yes | no}
+##     default "no"
+##
+##  When DomainKeys verification is enabled, multiple Authentication-Results
+##  will be added, one for DK and one for DKIM.  With this enabled, only
+##  a DKIM result will be reported unless DKIM failed but DK passed, in which
+##  case only a DK result will be reported.
+
+# SingleAuthResult     no
+
+##  SMTPURI uri
+##
+##  Specifies a URI (e.g., "smtp://localhost") to which mail should be sent
+##  via SMTP when notifications are generated.
+
+# Socket smtp://localhost
+
+##  Socket socketspec
+##
+##  Names the socket where this filter should listen for milter connections
+##  from the MTA.  Required.  Should be in one of these forms:
+##
+##  inet:port@address          to listen on a specific interface
+##  inet:port                  to listen on all interfaces
+##  local:/path/to/socket      to listen on a UNIX domain socket
+
+Socket                 inet:port@localhost
+
+##  SoftwareHeader { yes | no }
+##     default "no"
+##
+##  Add a DKIM-Filter header field to messages passing through this filter
+##  to identify messages it has processed.
+
+# SoftwareHeader       no
+
+##  StrictHeaders { yes | no }
+##     default "no"
+##
+##  Requests that the DKIM library refuse to process a message whose
+##  header fields do not conform to the standards, in particular Section 3.6
+##  of RFC5322.
+
+# StrictHeaders                no
+
+##  StrictTestMode { yes | no }
+##     default "no"
+##
+##  Selects strict CRLF mode during testing (see the "-t" command line
+##  flag in the opendkim(8) man page).  Messages for which all header
+##  fields and body lines are not CRLF-terminated are considered malformed
+##  and will produce an error.
+
+# StrictTestMode       no
+
+##  SubDomains { yes | no }
+##     default "no"
+##
+##  Sign for subdomains as well?
+
+# SubDomains           No
+
+##  Syslog { yes | no }
+##     default "yes"
+##
+##  Log informational and error activity to syslog?
+
+Syslog                 Yes
+
+##  SyslogFacility      facility
+##     default "mail"
+##
+##  Valid values are :
+##      auth cron daemon kern lpr mail news security syslog user uucp 
+##      local0 local1 local2 local3 local4 local5 local6 local7
+##
+##  syslog facility to be used
+
+# SyslogFacility       mail
+
+##  SyslogSuccess { yes | no }
+##     default "no"
+##
+##  Log success activity to syslog?
+
+# SyslogSuccess                No
+
+##  TemporaryDirectory path
+##     default /tmp
+##
+##  Specifies which directory will be used for creating temporary files
+##  during message processing.
+
+# TemporaryDirectory   /tmp
+
+##  TestPublicKeys filename
+##     default (none)
+##
+##  Names a file from which public keys should be read.  Intended for use
+##  only during automated testing.
+
+# TestPublicKeys       /tmp/testkeys
+
+##  TrustAnchorFile filename
+##     default (none)
+##
+## Specifies a file from which trust anchor data should be read when doing
+## DNS queries and applying the DNSSEC protocol.  See the Unbound documentation
+## at http://unbound.net for the expected format of this file.
+
+# TrustAnchorFile      /var/named/trustanchor
+
+##  UMask mask
+##     default (none)
+##
+##  Change the process umask for file creation to the specified value.
+##  The system has its own default which will be used (usually 022).
+##  See the umask(2) man page for more information.
+
+# UMask                        022
+
+# UnboundConfigFile    /var/named/unbound.conf
+
+##  Userid userid
+##     default (none)
+##
+##  Change to user "userid" before starting normal operation?  May include
+##  a group ID as well, separated from the userid by a colon.
+
+# UserID               userid
+
+AutoRestart             Yes
+AutoRestartRate         10/1h
+UMask                   002
+Syslog                  yes
+SyslogSuccess           Yes
+LogWhy                  Yes
+
+Canonicalization        relaxed/simple
+
+ExternalIgnoreList      refile:/usr/local/etc/opendkim/TrustedHosts
+InternalHosts           refile:/usr/local/etc/opendkim/TrustedHosts
+KeyTable                refile:/usr/local/etc/opendkim/KeyTable
+SigningTable            refile:/usr/local/etc/opendkim/SigningTable
+
+Mode                    sv
+PidFile                 /var/run/opendkim/opendkim.pid
+SignatureAlgorithm      rsa-sha256
+
+UserID                  opendkim:opendkim
+
+Socket                  local:/var/run/opendkim/socket
+#inet:12301@localhost
+
+RequireSafeKeys false
+
diff --git a/mail/opendkim.conf.sample b/mail/opendkim.conf.sample
new file mode 100644
index 0000000..684b95f
--- /dev/null
+++ b/mail/opendkim.conf.sample
(omitted)
diff --git a/rc.d/milter-opendkim b/rc.d/milter-opendkim
new file mode 100755
index 0000000..312cc20
--- /dev/null
+++ b/rc.d/milter-opendkim
@@ -0,0 +1,206 @@
+#!/bin/sh
+#
+# $FreeBSD: head/mail/opendkim/files/milter-opendkim.in 481909 2018-10-12 15:30:35Z uqs $
+#
+
+# PROVIDE: milter-opendkim
+# REQUIRE: DAEMON
+# BEFORE: mail
+# KEYWORD: shutdown
+
+# Define these milteropendkim_* variables in one of these files:
+#      /etc/rc.conf
+#      /etc/rc.conf.local
+#      /etc/rc.conf.d/milteropendkim
+#
+# milteropendkim_enable (bool):   Set to "NO" by default.
+#                             Set it to "YES" to enable dkim-milter
+# milteropendkim_uid (str):       Set username to run milter.
+# milteropendkim_gid (str):       Set group to run milter.
+# milteropendkim_profiles (list): Set to "" by default.
+#                             Define your profiles here.
+# milteropendkim_cfgfile (str):   Configuration file. See opendkim.conf(5)
+#
+# milteropendkim_${profile}_* :   Variables per profile.
+#                             Sockets must be different from each other.
+#
+# milteropendkim_socket_perms (str):
+#                                 Permissions for local|unix socket.
+#
+#  all parameters below now can be set in opendkim.conf(5).
+# milteropendkim_socket (str):    Path to the milter socket.
+# milteropendkim_domain (str):    Domainpart of From: in mails to sign.
+# milteropendkim_key (str):       Path to the private key file to sign with.
+# milteropendkim_selector (str):  Selector to use when signing
+# milteropendkim_alg (str):       Algorithm to use when signing
+# milteropendkim_flags (str):     Flags passed to start command.
+
+. /etc/rc.subr
+
+name="milteropendkim"
+rcvar=milteropendkim_enable
+
+extra_commands="reload"
+start_precmd="dkim_prepcmd"
+start_postcmd="dkim_start_postcmd"
+stop_postcmd="dkim_postcmd"
+command="/usr/local/sbin/opendkim"
+_piddir="/var/run/milteropendkim"
+pidfile="${_piddir}/pid"
+sig_reload="USR1"
+
+load_rc_config $name
+
+#
+# DO NOT CHANGE THESE DEFAULT VALUES HERE
+#
+: ${milteropendkim_enable="NO"}
+: ${milteropendkim_uid="mailnull"}
+: ${milteropendkim_gid="mailnull"}
+: ${milteropendkim_cfgfile="/usr/local/etc/mail/opendkim.conf"}
+: ${milteropendkim_socket_perms="0755"}
+
+# Options other than above can be set with $milteropendkim_flags.
+# see dkim-milter documentation for detail.
+
+if [ -n "$2" ]; then
+    profile="$2"
+    if [ "x${milteropendkim_profiles}" != "x" ]; then
+       pidfile="${_piddir}/${profile}.pid"
+       eval milteropendkim_enable="\${milteropendkim_${profile}_enable:-${milteropendkim_enable}}"
+       eval milteropendkim_socket="\${milteropendkim_${profile}_socket:-}"
+       eval milteropendkim_socket_perms="\${milteropendkim_${profile}_socket_perms:-}"
+       if [ "x${milteropendkim_socket}" = "x" ];then
+           echo "You must define a socket (milteropendkim_${profile}_socket)"
+           exit 1
+       fi
+       eval milteropendkim_cfgfile="\${milteropendkim_${profile}_cfgfile:-${milteropendkim_cfgfile}}"
+       eval milteropendkim_domain="\${milteropendkim_${profile}_domain:-${milteropendkim_domain}}"
+       eval milteropendkim_key="\${milteropendkim_${profile}_key:-${milteropendkim_key}}"
+       eval milteropendkim_selector="\${milteropendkim_${profile}_selector:-${milteropendkim_selector}}"
+       eval milteropendkim_alg="\${milteropendkim_${profile}_alg:-${milteropendkim_alg}}"
+       eval milteropendkim_flags="\${milteropendkim_${profile}_flags:-${milteropendkim_flags}}"
+       if [ -f "${milteropendkim_cfgfile}" ];then
+           milteropendkim_cfgfile="-x ${milteropendkim_cfgfile}"
+       else
+           milteropendkim_cfgfile=""
+       fi
+       if [ "x${milteropendkim_socket}" != "x" ];then
+           _socket_prefix="-p"
+       fi
+       if [ "x${milteropendkim_uid}" != "x" ];then
+           _uid_prefix="-u"
+           if [ "x${milteropendkim_gid}" != "x" ];then
+               milteropendkim_uid=${milteropendkim_uid}:${milteropendkim_gid}
+           fi
+       fi
+       if [ "x${milteropendkim_domain}" != "x" ];then
+           milteropendkim_domain="-d ${milteropendkim_domain}"
+       fi
+       if [ "x${milteropendkim_key}" != "x" ];then
+           milteropendkim_key="-k ${milteropendkim_key}"
+       fi
+       if [ "x${milteropendkim_selector}" != "x" ];then
+           milteropendkim_selector="-s ${milteropendkim_selector}"
+       fi
+       if [ "x${milteropendkim_alg}" != "x" ];then
+           milteropendkim_alg="-S ${milteropendkim_alg}"
+       fi
+       command_args="-l ${_socket_prefix} ${milteropendkim_socket} ${_uid_prefix} ${milteropendkim_uid} -P ${pidfile} ${milteropendkim_cfgfile} ${milteropendkim_domain} ${milteropendkim_key} ${milteropendkim_selector} ${milteropendkim_alg}"
+    else
+       echo "$0: extra argument ignored"
+    fi
+else
+    if [ "x${milteropendkim_profiles}" != "x" -a "x$1" != "x" ]; then
+       if [ "x$1" != "xrestart" ]; then
+           for profile in ${milteropendkim_profiles}; do
+               echo "===> milteropendkim profile: ${profile}"
+               /usr/local/etc/rc.d/milter-opendkim $1 ${profile}
+               retcode="$?"
+               if [ "0${retcode}" -ne 0 ]; then
+                   failed="${profile} (${retcode}) ${failed:-}"
+               else
+                   success="${profile} ${success:-}"
+               fi
+           done
+           exit 0
+       else
+           restart_precmd=""
+       fi
+    else
+       if [ -f "${milteropendkim_cfgfile}" ];then
+           milteropendkim_cfgfile="-x ${milteropendkim_cfgfile}"
+       else
+           milteropendkim_cfgfile=""
+       fi
+       if [ "x${milteropendkim_socket}" != "x" ];then
+           _socket_prefix="-p"
+       fi
+       if [ "x${milteropendkim_uid}" != "x" ];then
+           _uid_prefix="-u"
+           if [ "x${milteropendkim_gid}" != "x" ];then
+               milteropendkim_uid=${milteropendkim_uid}:${milteropendkim_gid}
+           fi
+       fi
+       if [ "x${milteropendkim_domain}" != "x" ];then
+           milteropendkim_domain="-d ${milteropendkim_domain}"
+       fi
+       if [ "x${milteropendkim_key}" != "x" ];then
+           milteropendkim_key="-k ${milteropendkim_key}"
+       fi
+       if [ "x${milteropendkim_selector}" != "x" ];then
+           milteropendkim_selector="-s ${milteropendkim_selector}"
+       fi
+       if [ "x${milteropendkim_alg}" != "x" ];then
+           milteropendkim_alg="-S ${milteropendkim_alg}"
+       fi
+       command_args="-l ${_socket_prefix} ${milteropendkim_socket} ${_uid_prefix} ${milteropendkim_uid} -P ${pidfile} ${milteropendkim_cfgfile} ${milteropendkim_domain} ${milteropendkim_key} ${milteropendkim_selector} ${milteropendkim_alg}"
+    fi
+fi
+
+dkim_prepcmd ()
+{
+    if [ -S ${milteropendkim_socket##local:} ] ; then
+        rm -f ${milteropendkim_socket##local:}
+    elif [ -S ${milteropendkim_socket##unix:} ] ; then
+        rm -f ${milteropendkim_socket##unix:}
+    fi
+    if [ ! -d ${_piddir} ] ; then
+       mkdir -p ${_piddir}
+    fi
+    if [ -n "${milteropendkim_uid}" ] ; then
+       chown ${milteropendkim_uid} ${_piddir}
+    fi
+    if [ -n "${milteropendkim_gid}" ] ; then
+       chgrp ${milteropendkim_gid} ${_piddir}
+    fi
+    chmod ${milteropendkim_socket_perms} ${_piddir}
+}
+
+dkim_start_postcmd ()
+{
+    if [ "x${milteropendkim_socket}" != "x" ] ; then
+       # postcmd is executed too fast and socket is not created before checking...
+       sleep 1
+       if [ -S ${milteropendkim_socket##local:} ] ; then
+           chmod ${milteropendkim_socket_perms} ${milteropendkim_socket##local:}
+       elif [ -S ${milteropendkim_socket##unix:} ] ; then
+           chmod ${milteropendkim_socket_perms} ${milteropendkim_socket##unix:}
+       fi
+    fi
+}
+
+dkim_postcmd()
+{
+    if [ "x${milteropendkim_socket}" != "x" ] ; then
+       if [ -S ${milteropendkim_socket##local:} ] ; then
+           rm -f ${milteropendkim_socket##local:}
+       elif [ -S ${milteropendkim_socket##unix:} ] ; then
+           rm -f ${milteropendkim_socket##unix:}
+       fi
+    fi
+    # just if the directory is empty
+    rmdir ${_piddir} > /dev/null 2>&1
+}
+
+run_rc_command "$1"
diff --git a/rc.d/unbound b/rc.d/unbound
new file mode 100755
index 0000000..6b25758
--- /dev/null
+++ b/rc.d/unbound
@@ -0,0 +1,50 @@
+#!/bin/sh
+#
+# $FreeBSD: head/dns/unbound/files/unbound.in 470572 2018-05-21 19:28:28Z brnrd $
+#
+# unbound freebsd startup rc.d script, modified from the named script.
+# uses the default unbound installation path and pidfile location.
+# copy this to /etc/rc.d/unbound
+# and put unbound_enable="YES" into rc.conf
+#
+# unbound_anchorflags can be used to allow you to pass a custom flags to
+# unbound-anchor.  Examples include a custom resolv.conf (-f) or a custom
+# root.hints (-r).  Useful for when /etc/resolv.conf only contains 127.0.0.1
+
+# PROVIDE: unbound
+# REQUIRE: SERVERS cleanvar
+# KEYWORD: shutdown
+
+. /etc/rc.subr
+
+name="unbound"
+rcvar=unbound_enable
+
+command="/usr/local/sbin/unbound"
+extra_commands="reload"
+start_precmd="start_precmd"
+
+load_rc_config $name
+
+pidfile=`/usr/local/sbin/unbound-checkconf -o pidfile ${unbound_conf}`
+unbound_enable=${unbound_enable:-"NO"}
+unbound_anchorflags=${unbound_anchorflags:-""}
+unbound_conf=${unbound_conf:-"/usr/local/etc/unbound/unbound.conf"}
+unbound_flags=${unbound_flags:-" -c ${unbound_conf}"}
+
+reload_precmd="/usr/local/sbin/unbound-checkconf ${unbound_conf} >/dev/null"
+
+start_precmd()
+{
+       echo -n "Obtaining a trust anchor:"
+       if [ "${unbound_anchorflags}T" = "T" ]; then
+               su -m unbound -c /usr/local/sbin/unbound-anchor
+       else
+               su -m unbound -c "/usr/local/sbin/unbound-anchor ${unbound_anchorflags}"
+       fi
+       echo .
+       /usr/local/sbin/unbound-checkconf ${unbound_conf} > /dev/null
+       return $?
+}
+
+run_rc_command "$1"
diff --git a/unbound/unbound.conf b/unbound/unbound.conf
new file mode 100644
index 0000000..9166a29
--- /dev/null
+++ b/unbound/unbound.conf
@@ -0,0 +1,950 @@
+#
+# Example configuration file.
+#
+# See unbound.conf(5) man page, version 1.8.1.
+#
+# this is a comment.
+
+#Use this to include other text into the file.
+#include: "otherfile.conf"
+
+# The server clause sets the main parameters.
+server:
+       # whitespace is not necessary, but looks cleaner.
+
+       # verbosity number, 0 is least verbose. 1 is default.
+       verbosity: 1
+
+       # print statistics to the log (for every thread) every N seconds.
+       # Set to "" or 0 to disable. Default is disabled.
+       # statistics-interval: 0
+
+       # enable shm for stats, default no.  if you enable also enable
+       # statistics-interval, every time it also writes stats to the
+       # shared memory segment keyed with shm-key.
+       # shm-enable: no
+
+       # shm for stats uses this key, and key+1 for the shared mem segment.
+       # shm-key: 11777
+
+       # enable cumulative statistics, without clearing them after printing.
+       # statistics-cumulative: no
+
+       # enable extended statistics (query types, answer codes, status)
+       # printed from unbound-control. default off, because of speed.
+       # extended-statistics: no
+
+       # number of threads to create. 1 disables threading.
+       # num-threads: 1
+
+       # specify the interfaces to answer queries from by ip-address.
+       # The default is to listen to localhost (127.0.0.1 and ::1).
+       # specify 0.0.0.0 and ::0 to bind to all available interfaces.
+       # specify every interface[@port] on a new 'interface:' labelled line.
+       # The listen interfaces are not changed on reload, only on restart.
+       # interface: 192.0.2.153
+       # interface: 192.0.2.154
+       # interface: 192.0.2.154@5003
+       # interface: 2001:DB8::5
+
+       # enable this feature to copy the source address of queries to reply.
+       # Socket options are not supported on all platforms. experimental.
+       # interface-automatic: no
+
+       # port to answer queries from
+       # port: 53
+
+       # specify the interfaces to send outgoing queries to authoritative
+       # server from by ip-address. If none, the default (all) interface
+       # is used. Specify every interface on a 'outgoing-interface:' line.
+       # outgoing-interface: 192.0.2.153
+       # outgoing-interface: 2001:DB8::5
+       # outgoing-interface: 2001:DB8::6
+
+       # Specify a netblock to use remainder 64 bits as random bits for
+       # upstream queries.  Uses freebind option (Linux).
+       # outgoing-interface: 2001:DB8::/64
+       # Also (Linux:) ip -6 addr add 2001:db8::/64 dev lo
+       # And: ip -6 route add local 2001:db8::/64 dev lo
+       # And set prefer-ip6: yes to use the ip6 randomness from a netblock.
+       # Set this to yes to prefer ipv6 upstream servers over ipv4.
+       # prefer-ip6: no
+
+       # number of ports to allocate per thread, determines the size of the
+       # port range that can be open simultaneously.  About double the
+       # num-queries-per-thread, or, use as many as the OS will allow you.
+       # outgoing-range: 4096
+
+       # permit unbound to use this port number or port range for
+       # making outgoing queries, using an outgoing interface.
+       # outgoing-port-permit: 32768
+
+       # deny unbound the use this of port number or port range for
+       # making outgoing queries, using an outgoing interface.
+       # Use this to make sure unbound does not grab a UDP port that some
+       # other server on this computer needs. The default is to avoid
+       # IANA-assigned port numbers.
+       # If multiple outgoing-port-permit and outgoing-port-avoid options
+       # are present, they are processed in order.
+       # outgoing-port-avoid: "3200-3208"
+
+       # number of outgoing simultaneous tcp buffers to hold per thread.
+       # outgoing-num-tcp: 10
+
+       # number of incoming simultaneous tcp buffers to hold per thread.
+       # incoming-num-tcp: 10
+
+       # buffer size for UDP port 53 incoming (SO_RCVBUF socket option).
+       # 0 is system default.  Use 4m to catch query spikes for busy servers.
+       # so-rcvbuf: 0
+
+       # buffer size for UDP port 53 outgoing (SO_SNDBUF socket option).
+       # 0 is system default.  Use 4m to handle spikes on very busy servers.
+       # so-sndbuf: 0
+
+       # use SO_REUSEPORT to distribute queries over threads.
+       # so-reuseport: yes
+
+       # use IP_TRANSPARENT so the interface: addresses can be non-local
+       # and you can config non-existing IPs that are going to work later on
+       # (uses IP_BINDANY on FreeBSD).
+       # ip-transparent: no
+
+       # use IP_FREEBIND so the interface: addresses can be non-local
+       # and you can bind to nonexisting IPs and interfaces that are down.
+       # Linux only.  On Linux you also have ip-transparent that is similar.
+       # ip-freebind: no
+
+       # EDNS reassembly buffer to advertise to UDP peers (the actual buffer
+       # is set with msg-buffer-size). 1472 can solve fragmentation (timeouts)
+       # edns-buffer-size: 4096
+
+       # Maximum UDP response size (not applied to TCP response).
+       # Suggested values are 512 to 4096. Default is 4096. 65536 disables it.
+       # max-udp-size: 4096
+
+       # buffer size for handling DNS data. No messages larger than this
+       # size can be sent or received, by UDP or TCP. In bytes.
+       # msg-buffer-size: 65552
+
+       # the amount of memory to use for the message cache.
+       # plain value in bytes or you can append k, m or G. default is "4Mb".
+       # msg-cache-size: 4m
+
+       # the number of slabs to use for the message cache.
+       # the number of slabs must be a power of 2.
+       # more slabs reduce lock contention, but fragment memory usage.
+       # msg-cache-slabs: 4
+
+       # the number of queries that a thread gets to service.
+       # num-queries-per-thread: 1024
+
+       # if very busy, 50% queries run to completion, 50% get timeout in msec
+       # jostle-timeout: 200
+
+       # msec to wait before close of port on timeout UDP. 0 disables.
+       # delay-close: 0
+
+       # the amount of memory to use for the RRset cache.
+       # plain value in bytes or you can append k, m or G. default is "4Mb".
+       # rrset-cache-size: 4m
+
+       # the number of slabs to use for the RRset cache.
+       # the number of slabs must be a power of 2.
+       # more slabs reduce lock contention, but fragment memory usage.
+       # rrset-cache-slabs: 4
+
+       # the time to live (TTL) value lower bound, in seconds. Default 0.
+       # If more than an hour could easily give trouble due to stale data.
+       # cache-min-ttl: 0
+
+       # the time to live (TTL) value cap for RRsets and messages in the
+       # cache. Items are not cached for longer. In seconds.
+       # cache-max-ttl: 86400
+
+       # the time to live (TTL) value cap for negative responses in the cache
+       # cache-max-negative-ttl: 3600
+
+       # the time to live (TTL) value for cached roundtrip times, lameness and
+       # EDNS version information for hosts. In seconds.
+       # infra-host-ttl: 900
+
+       # minimum wait time for responses, increase if uplink is long. In msec.
+       # infra-cache-min-rtt: 50
+
+       # the number of slabs to use for the Infrastructure cache.
+       # the number of slabs must be a power of 2.
+       # more slabs reduce lock contention, but fragment memory usage.
+       # infra-cache-slabs: 4
+
+       # the maximum number of hosts that are cached (roundtrip, EDNS, lame).
+       # infra-cache-numhosts: 10000
+
+       # define a number of tags here, use with local-zone, access-control.
+       # repeat the define-tag statement to add additional tags.
+       # define-tag: "tag1 tag2 tag3"
+
+       # Enable IPv4, "yes" or "no".
+       # do-ip4: yes
+
+       # Enable IPv6, "yes" or "no".
+       # do-ip6: yes
+
+       # Enable UDP, "yes" or "no".
+       # do-udp: yes
+
+       # Enable TCP, "yes" or "no".
+       # do-tcp: yes
+
+       # upstream connections use TCP only (and no UDP), "yes" or "no"
+       # useful for tunneling scenarios, default no.
+       # tcp-upstream: no
+
+       # upstream connections also use UDP (even if do-udp is no).
+       # useful if if you want UDP upstream, but don't provide UDP downstream.
+       # udp-upstream-without-downstream: no
+
+       # Maximum segment size (MSS) of TCP socket on which the server
+       # responds to queries. Default is 0, system default MSS.
+       # tcp-mss: 0
+
+       # Maximum segment size (MSS) of TCP socket for outgoing queries.
+       # Default is 0, system default MSS.
+       # outgoing-tcp-mss: 0
+
+       # Idle TCP timeout, connection closed in milliseconds
+       # tcp-idle-timeout: 30000
+
+       # Enable EDNS TCP keepalive option.
+       # edns-tcp-keepalive: no
+
+       # Timeout for EDNS TCP keepalive, in msec.
+       # edns-tcp-keepalive-timeout: 120000
+
+       # Use systemd socket activation for UDP, TCP, and control sockets.
+       # use-systemd: no
+
+       # Detach from the terminal, run in background, "yes" or "no".
+       # Set the value to "no" when unbound runs as systemd service.
+       # do-daemonize: yes
+
+       # control which clients are allowed to make (recursive) queries
+       # to this server. Specify classless netblocks with /size and action.
+       # By default everything is refused, except for localhost.
+       # Choose deny (drop message), refuse (polite error reply),
+       # allow (recursive ok), allow_setrd (recursive ok, rd bit is forced on),
+       # allow_snoop (recursive and nonrecursive ok)
+       # deny_non_local (drop queries unless can be answered from local-data)
+       # refuse_non_local (like deny_non_local but polite error reply).
+       # access-control: 0.0.0.0/0 refuse
+       # access-control: 127.0.0.0/8 allow
+       # access-control: ::0/0 refuse
+       # access-control: ::1 allow
+       # access-control: ::ffff:127.0.0.1 allow
+
+       # tag access-control with list of tags (in "" with spaces between)
+       # Clients using this access control element use localzones that
+       # are tagged with one of these tags.
+       # access-control-tag: 192.0.2.0/24 "tag2 tag3"
+
+       # set action for particular tag for given access control element
+       # if you have multiple tag values, the tag used to lookup the action
+       # is the first tag match between access-control-tag and local-zone-tag
+       # where "first" comes from the order of the define-tag values.
+       # access-control-tag-action: 192.0.2.0/24 tag3 refuse
+
+       # set redirect data for particular tag for access control element
+       # access-control-tag-data: 192.0.2.0/24 tag2 "A 127.0.0.1"
+
+       # Set view for access control element
+       # access-control-view: 192.0.2.0/24 viewname
+
+       # if given, a chroot(2) is done to the given directory.
+       # i.e. you can chroot to the working directory, for example,
+       # for extra security, but make sure all files are in that directory.
+       #
+       # If chroot is enabled, you should pass the configfile (from the
+       # commandline) as a full path from the original root. After the
+       # chroot has been performed the now defunct portion of the config
+       # file path is removed to be able to reread the config after a reload.
+       #
+       # All other file paths (working dir, logfile, roothints, and
+       # key files) can be specified in several ways:
+       #       o as an absolute path relative to the new root.
+       #       o as a relative path to the working directory.
+       #       o as an absolute path relative to the original root.
+       # In the last case the path is adjusted to remove the unused portion.
+       #
+       # The pid file can be absolute and outside of the chroot, it is
+       # written just prior to performing the chroot and dropping permissions.
+       #
+       # Additionally, unbound may need to access /dev/random (for entropy).
+       # How to do this is specific to your OS.
+       #
+       # If you give "" no chroot is performed. The path must not end in a /.
+       # chroot: "/usr/local/etc/unbound"
+
+       # if given, user privileges are dropped (after binding port),
+       # and the given username is assumed. Default is user "unbound".
+       # If you give "" no privileges are dropped.
+       # username: "unbound"
+
+       # the working directory. The relative files in this config are
+       # relative to this directory. If you give "" the working directory
+       # is not changed.
+       # If you give a server: directory: dir before include: file statements
+       # then those includes can be relative to the working directory.
+       # directory: "/usr/local/etc/unbound"
+
+       # the log file, "" means log to stderr.
+       # Use of this option sets use-syslog to "no".
+       # logfile: ""
+
+       # Log to syslog(3) if yes. The log facility LOG_DAEMON is used to
+       # log to. If yes, it overrides the logfile.
+       # use-syslog: yes
+
+       # Log identity to report. if empty, defaults to the name of argv[0]
+       # (usually "unbound").
+       # log-identity: ""
+
+       # print UTC timestamp in ascii to logfile, default is epoch in seconds.
+       # log-time-ascii: no
+
+       # print one line with time, IP, name, type, class for every query.
+       # log-queries: no
+
+       # print one line per reply, with time, IP, name, type, class, rcode,
+       # timetoresolve, fromcache and responsesize.
+       # log-replies: no
+
+       # log the local-zone actions, like local-zone type inform is enabled
+       # also for the other local zone types.
+       # log-local-actions: no
+
+       # print log lines that say why queries return SERVFAIL to clients.
+       # log-servfail: no
+
+       # the pid file. Can be an absolute path outside of chroot/work dir.
+       # pidfile: "/usr/local/etc/unbound/unbound.pid"
+
+       # file to read root hints from.
+       # get one from https://www.internic.net/domain/named.cache
+       # root-hints: ""
+
+       # enable to not answer id.server and hostname.bind queries.
+       # hide-identity: no
+
+       # enable to not answer version.server and version.bind queries.
+       # hide-version: no
+
+       # enable to not answer trustanchor.unbound queries.
+       # hide-trustanchor: no
+
+       # the identity to report. Leave "" or default to return hostname.
+       # identity: ""
+
+       # the version to report. Leave "" or default to return package version.
+       # version: ""
+
+       # the target fetch policy.
+       # series of integers describing the policy per dependency depth.
+       # The number of values in the list determines the maximum dependency
+       # depth the recursor will pursue before giving up. Each integer means:
+       #       -1 : fetch all targets opportunistically,
+       #       0: fetch on demand,
+       #       positive value: fetch that many targets opportunistically.
+       # Enclose the list of numbers between quotes ("").
+       # target-fetch-policy: "3 2 1 0 0"
+
+       # Harden against very small EDNS buffer sizes.
+       # harden-short-bufsize: no
+
+       # Harden against unseemly large queries.
+       # harden-large-queries: no
+
+       # Harden against out of zone rrsets, to avoid spoofing attempts.
+       # harden-glue: yes
+
+       # Harden against receiving dnssec-stripped data. If you turn it
+       # off, failing to validate dnskey data for a trustanchor will
+       # trigger insecure mode for that zone (like without a trustanchor).
+       # Default on, which insists on dnssec data for trust-anchored zones.
+       # harden-dnssec-stripped: yes
+
+       # Harden against queries that fall under dnssec-signed nxdomain names.
+       # harden-below-nxdomain: yes
+
+       # Harden the referral path by performing additional queries for
+       # infrastructure data.  Validates the replies (if possible).
+       # Default off, because the lookups burden the server.  Experimental
+       # implementation of draft-wijngaards-dnsext-resolver-side-mitigation.
+       # harden-referral-path: no
+
+       # Harden against algorithm downgrade when multiple algorithms are
+       # advertised in the DS record.  If no, allows the weakest algorithm
+       # to validate the zone.
+       # harden-algo-downgrade: no
+
+       # Sent minimum amount of information to upstream servers to enhance
+       # privacy. Only sent minimum required labels of the QNAME and set QTYPE
+       # to A when possible.
+       # qname-minimisation: yes
+
+       # QNAME minimisation in strict mode. Do not fall-back to sending full
+       # QNAME to potentially broken nameservers. A lot of domains will not be
+       # resolvable when this option in enabled.
+       # This option only has effect when qname-minimisation is enabled.
+       # qname-minimisation-strict: no
+
+       # Aggressive NSEC uses the DNSSEC NSEC chain to synthesize NXDOMAIN
+       # and other denials, using information from previous NXDOMAINs answers.
+       # aggressive-nsec: no
+
+       # Use 0x20-encoded random bits in the query to foil spoof attempts.
+       # This feature is an experimental implementation of draft dns-0x20.
+       # use-caps-for-id: no
+
+       # Domains (and domains in them) without support for dns-0x20 and
+       # the fallback fails because they keep sending different answers.
+       # caps-whitelist: "licdn.com"
+       # caps-whitelist: "senderbase.org"
+
+       # Enforce privacy of these addresses. Strips them away from answers.
+       # It may cause DNSSEC validation to additionally mark it as bogus.
+       # Protects against 'DNS Rebinding' (uses browser as network proxy).
+       # Only 'private-domain' and 'local-data' names are allowed to have
+       # these private addresses. No default.
+       # private-address: 10.0.0.0/8
+       # private-address: 172.16.0.0/12
+       # private-address: 192.168.0.0/16
+       # private-address: 169.254.0.0/16
+       # private-address: fd00::/8
+       # private-address: fe80::/10
+       # private-address: ::ffff:0:0/96
+
+       # Allow the domain (and its subdomains) to contain private addresses.
+       # local-data statements are allowed to contain private addresses too.
+       # private-domain: "example.com"
+
+       # If nonzero, unwanted replies are not only reported in statistics,
+       # but also a running total is kept per thread. If it reaches the
+       # threshold, a warning is printed and a defensive action is taken,
+       # the cache is cleared to flush potential poison out of it.
+       # A suggested value is 10000000, the default is 0 (turned off).
+       # unwanted-reply-threshold: 0
+
+       # Do not query the following addresses. No DNS queries are sent there.
+       # List one address per entry. List classless netblocks with /size,
+       # do-not-query-address: 127.0.0.1/8
+       # do-not-query-address: ::1
+
+       # if yes, the above default do-not-query-address entries are present.
+       # if no, localhost can be queried (for testing and debugging).
+       # do-not-query-localhost: yes
+
+       # if yes, perform prefetching of almost expired message cache entries.
+       # prefetch: no
+
+       # if yes, perform key lookups adjacent to normal lookups.
+       # prefetch-key: no
+
+       # if yes, Unbound rotates RRSet order in response.
+       # rrset-roundrobin: no
+
+       # if yes, Unbound doesn't insert authority/additional sections
+       # into response messages when those sections are not required.
+       # minimal-responses: yes
+
+       # true to disable DNSSEC lameness check in iterator.
+       # disable-dnssec-lame-check: no
+
+       # module configuration of the server. A string with identifiers
+       # separated by spaces. Syntax: "[dns64] [validator] iterator"
+       # module-config: "validator iterator"
+
+       # File with trusted keys, kept uptodate using RFC5011 probes,
+       # initial file like trust-anchor-file, then it stores metadata.
+       # Use several entries, one per domain name, to track multiple zones.
+       #
+       # If you want to perform DNSSEC validation, run unbound-anchor before
+       # you start unbound (i.e. in the system boot scripts).  And enable:
+       # Please note usage of unbound-anchor root anchor is at your own risk
+       # and under the terms of our LICENSE (see that file in the source).
+       # auto-trust-anchor-file: "/usr/local/etc/unbound/root.key"
+
+       # trust anchor signaling sends a RFC8145 key tag query after priming.
+       # trust-anchor-signaling: yes
+       
+       # Root key trust anchor sentinel (draft-ietf-dnsop-kskroll-sentinel)
+       # root-key-sentinel: yes
+
+       # File with DLV trusted keys. Same format as trust-anchor-file.
+       # There can be only one DLV configured, it is trusted from root down.
+       # DLV is going to be decommissioned.  Please do not use it any more.
+       # dlv-anchor-file: "dlv.isc.org.key"
+
+       # File with trusted keys for validation. Specify more than one file
+       # with several entries, one file per entry.
+       # Zone file format, with DS and DNSKEY entries.
+       # Note this gets out of date, use auto-trust-anchor-file please.
+       # trust-anchor-file: ""
+
+       # Trusted key for validation. DS or DNSKEY. specify the RR on a
+       # single line, surrounded by "". TTL is ignored. class is IN default.
+       # Note this gets out of date, use auto-trust-anchor-file please.
+       # (These examples are from August 2007 and may not be valid anymore).
+       # trust-anchor: "nlnetlabs.nl. DNSKEY 257 3 5 AQPzzTWMz8qSWIQlfRnPckx2BiVmkVN6LPupO3mbz7FhLSnm26n6iG9N Lby97Ji453aWZY3M5/xJBSOS2vWtco2t8C0+xeO1bc/d6ZTy32DHchpW 6rDH1vp86Ll+ha0tmwyy9QP7y2bVw5zSbFCrefk8qCUBgfHm9bHzMG1U BYtEIQ=="
+       # trust-anchor: "jelte.nlnetlabs.nl. DS 42860 5 1 14D739EB566D2B1A5E216A0BA4D17FA9B038BE4A"
+
+       # File with trusted keys for validation. Specify more than one file
+       # with several entries, one file per entry. Like trust-anchor-file
+       # but has a different file format. Format is BIND-9 style format,
+       # the trusted-keys { name flag proto algo "key"; }; clauses are read.
+       # you need external update procedures to track changes in keys.
+       # trusted-keys-file: ""
+
+       # Ignore chain of trust. Domain is treated as insecure.
+       # domain-insecure: "example.com"
+
+       # Override the date for validation with a specific fixed date.
+       # Do not set this unless you are debugging signature inception
+       # and expiration. "" or "0" turns the feature off. -1 ignores date.
+       # val-override-date: ""
+
+       # The time to live for bogus data, rrsets and messages. This avoids
+       # some of the revalidation, until the time interval expires. in secs.
+       # val-bogus-ttl: 60
+
+       # The signature inception and expiration dates are allowed to be off
+       # by 10% of the signature lifetime (expir-incep) from our local clock.
+       # This leeway is capped with a minimum and a maximum.  In seconds.
+       # val-sig-skew-min: 3600
+       # val-sig-skew-max: 86400
+
+       # Should additional section of secure message also be kept clean of
+       # unsecure data. Useful to shield the users of this validator from
+       # potential bogus data in the additional section. All unsigned data
+       # in the additional section is removed from secure messages.
+       # val-clean-additional: yes
+
+       # Turn permissive mode on to permit bogus messages. Thus, messages
+       # for which security checks failed will be returned to clients,
+       # instead of SERVFAIL. It still performs the security checks, which
+       # result in interesting log files and possibly the AD bit in
+       # replies if the message is found secure. The default is off.
+       # val-permissive-mode: no
+
+       # Ignore the CD flag in incoming queries and refuse them bogus data.
+       # Enable it if the only clients of unbound are legacy servers (w2008)
+       # that set CD but cannot validate themselves.
+       # ignore-cd-flag: no
+
+       # Serve expired responses from cache, with TTL 0 in the response,
+       # and then attempt to fetch the data afresh.
+       # serve-expired: no
+       #
+       # Limit serving of expired responses to configured seconds after
+       # expiration. 0 disables the limit.
+       # serve-expired-ttl: 0
+       #
+       # Set the TTL of expired records to the serve-expired-ttl value after a
+       # failed attempt to retrieve the record from upstream. This makes sure
+       # that the expired records will be served as long as there are queries
+       # for it.
+       # serve-expired-ttl-reset: no
+
+       # Have the validator log failed validations for your diagnosis.
+       # 0: off. 1: A line per failed user query. 2: With reason and bad IP.
+       # val-log-level: 0
+
+       # It is possible to configure NSEC3 maximum iteration counts per
+       # keysize. Keep this table very short, as linear search is done.
+       # A message with an NSEC3 with larger count is marked insecure.
+       # List in ascending order the keysize and count values.
+       # val-nsec3-keysize-iterations: "1024 150 2048 500 4096 2500"
+
+       # instruct the auto-trust-anchor-file probing to add anchors after ttl.
+       # add-holddown: 2592000 # 30 days
+
+       # instruct the auto-trust-anchor-file probing to del anchors after ttl.
+       # del-holddown: 2592000 # 30 days
+
+       # auto-trust-anchor-file probing removes missing anchors after ttl.
+       # If the value 0 is given, missing anchors are not removed.
+       # keep-missing: 31622400 # 366 days
+
+       # debug option that allows very small holddown times for key rollover,
+       # otherwise the RFC mandates probe intervals must be at least 1 hour.
+       # permit-small-holddown: no
+
+       # the amount of memory to use for the key cache.
+       # plain value in bytes or you can append k, m or G. default is "4Mb".
+       # key-cache-size: 4m
+
+       # the number of slabs to use for the key cache.
+       # the number of slabs must be a power of 2.
+       # more slabs reduce lock contention, but fragment memory usage.
+       # key-cache-slabs: 4
+
+       # the amount of memory to use for the negative cache (used for DLV).
+       # plain value in bytes or you can append k, m or G. default is "1Mb".
+       # neg-cache-size: 1m
+
+       # By default, for a number of zones a small default 'nothing here'
+       # reply is built-in.  Query traffic is thus blocked.  If you
+       # wish to serve such zone you can unblock them by uncommenting one
+       # of the nodefault statements below.
+       # You may also have to use domain-insecure: zone to make DNSSEC work,
+       # unless you have your own trust anchors for this zone.
+       # local-zone: "localhost." nodefault
+       # local-zone: "127.in-addr.arpa." nodefault
+       # local-zone: "1.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa." nodefault
+       # local-zone: "onion." nodefault
+       # local-zone: "test." nodefault
+       # local-zone: "invalid." nodefault
+       # local-zone: "10.in-addr.arpa." nodefault
+       # local-zone: "16.172.in-addr.arpa." nodefault
+       # local-zone: "17.172.in-addr.arpa." nodefault
+       # local-zone: "18.172.in-addr.arpa." nodefault
+       # local-zone: "19.172.in-addr.arpa." nodefault
+       # local-zone: "20.172.in-addr.arpa." nodefault
+       # local-zone: "21.172.in-addr.arpa." nodefault
+       # local-zone: "22.172.in-addr.arpa." nodefault
+       # local-zone: "23.172.in-addr.arpa." nodefault
+       # local-zone: "24.172.in-addr.arpa." nodefault
+       # local-zone: "25.172.in-addr.arpa." nodefault
+       # local-zone: "26.172.in-addr.arpa." nodefault
+       # local-zone: "27.172.in-addr.arpa." nodefault
+       # local-zone: "28.172.in-addr.arpa." nodefault
+       # local-zone: "29.172.in-addr.arpa." nodefault
+       # local-zone: "30.172.in-addr.arpa." nodefault
+       # local-zone: "31.172.in-addr.arpa." nodefault
+       # local-zone: "168.192.in-addr.arpa." nodefault
+       # local-zone: "0.in-addr.arpa." nodefault
+       # local-zone: "254.169.in-addr.arpa." nodefault
+       # local-zone: "2.0.192.in-addr.arpa." nodefault
+       # local-zone: "100.51.198.in-addr.arpa." nodefault
+       # local-zone: "113.0.203.in-addr.arpa." nodefault
+       # local-zone: "255.255.255.255.in-addr.arpa." nodefault
+       # local-zone: "0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.0.ip6.arpa." nodefault
+       # local-zone: "d.f.ip6.arpa." nodefault
+       # local-zone: "8.e.f.ip6.arpa." nodefault
+       # local-zone: "9.e.f.ip6.arpa." nodefault
+       # local-zone: "a.e.f.ip6.arpa." nodefault
+       # local-zone: "b.e.f.ip6.arpa." nodefault
+       # local-zone: "8.b.d.0.1.0.0.2.ip6.arpa." nodefault
+       # And for 64.100.in-addr.arpa. to 127.100.in-addr.arpa.
+
+       # If unbound is running service for the local host then it is useful
+       # to perform lan-wide lookups to the upstream, and unblock the
+       # long list of local-zones above.  If this unbound is a dns server
+       # for a network of computers, disabled is better and stops information
+       # leakage of local lan information.
+       # unblock-lan-zones: no
+
+       # The insecure-lan-zones option disables validation for
+       # these zones, as if they were all listed as domain-insecure.
+       # insecure-lan-zones: no
+
+       # a number of locally served zones can be configured.
+       #       local-zone: <zone> <type>
+       #       local-data: "<resource record string>"
+       # o deny serves local data (if any), else, drops queries.
+       # o refuse serves local data (if any), else, replies with error.
+       # o static serves local data, else, nxdomain or nodata answer.
+       # o transparent gives local data, but resolves normally for other names
+       # o redirect serves the zone data for any subdomain in the zone.
+       # o nodefault can be used to normally resolve AS112 zones.
+       # o typetransparent resolves normally for other types and other names
+       # o inform acts like transparent, but logs client IP address
+       # o inform_deny drops queries and logs client IP address
+       # o always_transparent, always_refuse, always_nxdomain, resolve in
+       #   that way but ignore local data for that name
+       # o noview breaks out of that view towards global local-zones.
+       #
+       # defaults are localhost address, reverse for 127.0.0.1 and ::1
+       # and nxdomain for AS112 zones. If you configure one of these zones
+       # the default content is omitted, or you can omit it with 'nodefault'.
+       #
+       # If you configure local-data without specifying local-zone, by
+       # default a transparent local-zone is created for the data.
+       #
+       # You can add locally served data with
+       # local-zone: "local." static
+       # local-data: "mycomputer.local. IN A 192.0.2.51"
+       # local-data: 'mytext.local TXT "content of text record"'
+       #
+       # You can override certain queries with
+       # local-data: "adserver.example.com A 127.0.0.1"
+       #
+       # You can redirect a domain to a fixed address with
+       # (this makes example.com, www.example.com, etc, all go to 192.0.2.3)
+       # local-zone: "example.com" redirect
+       # local-data: "example.com A 192.0.2.3"
+       #
+       # Shorthand to make PTR records, "IPv4 name" or "IPv6 name".
+       # You can also add PTR records using local-data directly, but then
+       # you need to do the reverse notation yourself.
+       # local-data-ptr: "192.0.2.3 www.example.com"
+
+       # tag a localzone with a list of tag names (in "" with spaces between)
+       # local-zone-tag: "example.com" "tag2 tag3"
+
+       # add a netblock specific override to a localzone, with zone type
+       # local-zone-override: "example.com" 192.0.2.0/24 refuse
+
+       # service clients over TLS (on the TCP sockets), with plain DNS inside
+       # the TLS stream.  Give the certificate to use and private key.
+       # default is "" (disabled).  requires restart to take effect.
+       # tls-service-key: "path/to/privatekeyfile.key"
+       # tls-service-pem: "path/to/publiccertfile.pem"
+       # tls-port: 853
+
+       # request upstream over TLS (with plain DNS inside the TLS stream).
+       # Default is no.  Can be turned on and off with unbound-control.
+       # tls-upstream: no
+
+       # Certificates used to authenticate connections made upstream.
+       # tls-cert-bundle: ""
+
+       # Add system certs to the cert bundle, from the Windows Cert Store
+       # tls-win-cert: no
+
+       # Also serve tls on these port numbers (eg. 443, ...), by listing
+       # tls-additional-port: portno for each of the port numbers.
+
+       # DNS64 prefix. Must be specified when DNS64 is use.
+       # Enable dns64 in module-config.  Used to synthesize IPv6 from IPv4.
+       # dns64-prefix: 64:ff9b::0/96
+
+       # DNS64 ignore AAAA records for these domains and use A instead.
+       # dns64-ignore-aaaa: "example.com"
+
+       # ratelimit for uncached, new queries, this limits recursion effort.
+       # ratelimiting is experimental, and may help against randomqueryflood.
+       # if 0(default) it is disabled, otherwise state qps allowed per zone.
+       # ratelimit: 0
+
+       # ratelimits are tracked in a cache, size in bytes of cache (or k,m).
+       # ratelimit-size: 4m
+       # ratelimit cache slabs, reduces lock contention if equal to cpucount.
+       # ratelimit-slabs: 4
+
+       # 0 blocks when ratelimited, otherwise let 1/xth traffic through
+       # ratelimit-factor: 10
+
+       # override the ratelimit for a specific domain name.
+       # give this setting multiple times to have multiple overrides.
+       # ratelimit-for-domain: example.com 1000
+       # override the ratelimits for all domains below a domain name
+       # can give this multiple times, the name closest to the zone is used.
+       # ratelimit-below-domain: com 1000
+
+       # global query ratelimit for all ip addresses.
+       # feature is experimental.
+       # if 0(default) it is disabled, otherwise states qps allowed per ip address
+       # ip-ratelimit: 0
+
+       # ip ratelimits are tracked in a cache, size in bytes of cache (or k,m).
+       # ip-ratelimit-size: 4m
+       # ip ratelimit cache slabs, reduces lock contention if equal to cpucount.
+       # ip-ratelimit-slabs: 4
+
+       # 0 blocks when ip is ratelimited, otherwise let 1/xth traffic through
+       # ip-ratelimit-factor: 10
+
+       # Limit the number of connections simultaneous from a netblock
+       # tcp-connection-limit: 192.0.2.0/24 12
+
+       # what is considered a low rtt (ping time for upstream server), in msec
+       # low-rtt: 45
+       # select low rtt this many times out of 1000. 0 means the fast server
+       # select is disabled.  prefetches are not sped up.
+       # low-rtt-permil: 0
+
+       # Specific options for ipsecmod. unbound needs to be configured with
+       # --enable-ipsecmod for these to take effect.
+       #
+       # Enable or disable ipsecmod (it still needs to be defined in
+       # module-config above). Can be used when ipsecmod needs to be
+       # enabled/disabled via remote-control(below).
+       # ipsecmod-enabled: yes
+       #
+       # Path to executable external hook. It must be defined when ipsecmod is
+       # listed in module-config (above).
+       # ipsecmod-hook: "./my_executable"
+       #
+       # When enabled unbound will reply with SERVFAIL if the return value of
+       # the ipsecmod-hook is not 0.
+       # ipsecmod-strict: no
+       #
+       # Maximum time to live (TTL) for cached A/AAAA records with IPSECKEY.
+       # ipsecmod-max-ttl: 3600
+       #
+       # Reply with A/AAAA even if the relevant IPSECKEY is bogus. Mainly used for
+       # testing.
+       # ipsecmod-ignore-bogus: no
+       #
+       # Domains for which ipsecmod will be triggered. If not defined (default)
+       # all domains are treated as being whitelisted.
+       # ipsecmod-whitelist: "example.com"
+       # ipsecmod-whitelist: "nlnetlabs.nl"
+
+
+# Python config section. To enable:
+# o use --with-pythonmodule to configure before compiling.
+# o list python in the module-config string (above) to enable.
+# o and give a python-script to run.
+python:
+       # Script file to load
+       # python-script: "/usr/local/etc/unbound/ubmodule-tst.py"
+
+# Remote control config section.
+remote-control:
+       # Enable remote control with unbound-control(8) here.
+       # set up the keys and certificates with unbound-control-setup.
+       # control-enable: no
+
+       # what interfaces are listened to for remote control.
+       # give 0.0.0.0 and ::0 to listen to all interfaces.
+       # set to an absolute path to use a unix local name pipe, certificates
+       # are not used for that, so key and cert files need not be present.
+       # control-interface: 127.0.0.1
+       # control-interface: ::1
+
+       # port number for remote control operations.
+       # control-port: 8953
+
+       # for localhost, you can disable use of TLS by setting this to "no"
+       # For local sockets this option is ignored, and TLS is not used.
+       # control-use-cert: "yes"
+
+       # unbound server key file.
+       # server-key-file: "/usr/local/etc/unbound/unbound_server.key"
+
+       # unbound server certificate file.
+       # server-cert-file: "/usr/local/etc/unbound/unbound_server.pem"
+
+       # unbound-control key file.
+       # control-key-file: "/usr/local/etc/unbound/unbound_control.key"
+
+       # unbound-control certificate file.
+       # control-cert-file: "/usr/local/etc/unbound/unbound_control.pem"
+
+# Stub zones.
+# Create entries like below, to make all queries for 'example.com' and
+# 'example.org' go to the given list of nameservers. list zero or more
+# nameservers by hostname or by ipaddress. If you set stub-prime to yes,
+# the list is treated as priming hints (default is no).
+# With stub-first yes, it attempts without the stub if it fails.
+# Consider adding domain-insecure: name and local-zone: name nodefault
+# to the server: section if the stub is a locally served zone.
+# stub-zone:
+#      name: "example.com"
+#      stub-addr: 192.0.2.68
+#      stub-prime: no
+#      stub-first: no
+#      stub-tls-upstream: no
+#      stub-no-cache: no
+# stub-zone:
+#      name: "example.org"
+#      stub-host: ns.example.com.
+
+# Forward zones
+# Create entries like below, to make all queries for 'example.com' and
+# 'example.org' go to the given list of servers. These servers have to handle
+# recursion to other nameservers. List zero or more nameservers by hostname
+# or by ipaddress. Use an entry with name "." to forward all queries.
+# If you enable forward-first, it attempts without the forward if it fails.
+# forward-zone:
+#      name: "example.com"
+#      forward-addr: 192.0.2.68
+#      forward-addr: 192.0.2.73@5355  # forward to port 5355.
+#      forward-first: no
+#      forward-tls-upstream: no
+#      forward-no-cache: no
+# forward-zone:
+#      name: "example.org"
+#      forward-host: fwd.example.com
+
+# Authority zones
+# The data for these zones is kept locally, from a file or downloaded.
+# The data can be served to downstream clients, or used instead of the
+# upstream (which saves a lookup to the upstream).  The first example
+# has a copy of the root for local usage.  The second serves example.org
+# authoritatively.  zonefile: reads from file (and writes to it if you also
+# download it), master: fetches with AXFR and IXFR, or url to zonefile.
+# With allow-notify: you can give additional (apart from masters) sources of
+# notifies.
+# auth-zone:
+#      name: "."
+#      for-downstream: no
+#      for-upstream: yes
+#      fallback-enabled: yes
+#      master: b.root-servers.net
+#      master: c.root-servers.net
+#      master: e.root-servers.net
+#      master: f.root-servers.net
+#      master: g.root-servers.net
+#      master: k.root-servers.net
+# auth-zone:
+#      name: "example.org"
+#      for-downstream: yes
+#      for-upstream: yes
+#      zonefile: "example.org.zone"
+
+# Views
+# Create named views. Name must be unique. Map views to requests using
+# the access-control-view option. Views can contain zero or more local-zone
+# and local-data options. Options from matching views will override global
+# options. Global options will be used if no matching view is found.
+# With view-first yes, it will try to answer using the global local-zone and
+# local-data elements if there is no view specific match.
+# view:
+#      name: "viewname"
+#      local-zone: "example.com" redirect
+#      local-data: "example.com A 192.0.2.3"
+#      local-data-ptr: "192.0.2.3 www.example.com"
+#      view-first: no
+# view:
+#      name: "anotherview"
+#      local-zone: "example.com" refuse
+
+# DNSCrypt
+# Caveats:
+# 1. the keys/certs cannot be produced by unbound. You can use dnscrypt-wrapper
+#   for this: https://github.com/cofyc/dnscrypt-wrapper/blob/master/README.md#usage
+# 2. dnscrypt channel attaches to an interface. you MUST set interfaces to
+#   listen on `dnscrypt-port` with the follo0wing snippet:
+# server:
+#     interface: 0.0.0.0@443
+#     interface: ::0@443
+#
+# Finally, `dnscrypt` config has its own section.
+# dnscrypt:
+#     dnscrypt-enable: yes
+#     dnscrypt-port: 443
+#     dnscrypt-provider: 2.dnscrypt-cert.example.com.
+#     dnscrypt-secret-key: /path/unbound-conf/keys1/1.key
+#     dnscrypt-secret-key: /path/unbound-conf/keys2/1.key
+#     dnscrypt-provider-cert: /path/unbound-conf/keys1/1.cert
+#     dnscrypt-provider-cert: /path/unbound-conf/keys2/1.cert
+
+# CacheDB
+# Enable external backend DB as auxiliary cache.  Specify the backend name
+# (default is "testframe", which has no use other than for debugging and
+# testing) and backend-specific options.  The 'cachedb' module must be
+# included in module-config.
+# cachedb:
+#     backend: "testframe"
+#     # secret seed string to calculate hashed keys
+#     secret-seed: "default"
+#
+#     # For "redis" backend:
+#     # redis server's IP address or host name
+#     redis-server-host: 127.0.0.1
+#     # redis server's TCP port
+#     redis-server-port: 6379
+#     # timeout (in ms) for communication with the redis server
+#     redis-timeout: 100
diff --git a/unbound/unbound.conf.sample b/unbound/unbound.conf.sample
new file mode 100644
index 0000000..9166a29
--- /dev/null
+++ b/unbound/unbound.conf.sample
(omitted)
```

Here's the command-line history:
```
  231  cd /usr/local/etc/
  232  git status
  233  uname -a
  234  clear
  235  ls -l
  236  ls -l /usr/ports 
  237  cd /usr/
  238  rm ports
  239  mkdir ports
  240  crontab -l root
  241  crontab -l -u root
  242  cat /etc/passwd 
  243  crontab -l -u bbinfra
  244  crontab -e -u bbinfra
  245  pkg update
  246  pkg install opendkim
  247  nano -w /etc/rc.conf
  248  cat /etc/passwd 
  249  cd /usr/local/etc/
  250  ls -l
  251  git status
  252  git add .
  253  git commit -m 'safe' .
  254  cd /etc
  255  git add .
  256  git commit -m 'safe' .
  257  cd /usr/local/etc/
  258  ls -l
  259  cd op
  260  ls -l
  261  ls -lt
  262  pwd
  263  cd mail/
  264  ls -l
  265  pwd
  266  cd ..
  267  mkdir opendkim
  268  cd opendkim/
  269  ls -l
  270  nano -w SigningTable
  271  nano -w TrustedHosts
  272  ifconfig
  273  nano -w TrustedHosts
  274  ifconfig
  275  ls -l
  276  nano -w KeyTable
  277  pwd
  278  mkdir keys
  279  cd keys/
  280  mkdir buildbot.net
  281  cd buildbot.net/
  282  pwd
  283  ls -l
  284  opendkim-genkey -b 2048 -h rsa-sha256 -r -s 201901 -d rtems.org -v
  285  ls -l
  286  rm *
  287  opendkim-genkey -b 2048 -h rsa-sha256 -r -s 201901 -d buildbot.net -v
  288  ls -l
  289  mv 201901.private mail.private
  290  mv 201901.txt mail.txt
  291  pwd
  292  cd ..
  293  ls -l
  294  pwd
  295  cd ../../mail/
  296  ls -l
  297  git log opendkim.conf
  298  git diff fdb434483a63896c58f7117fdbc4d43254d92cd3
  299  git show fdb434483a63896c58f7117fdbc4d43254d92cd3
  300  ls -l
  301  git log .
  302  git diff .
  303  git diff fdb434483a63896c58f7117fdbc4d43254d92cd3:master
  304  git diff master:fdb434483a63896c58f7117fdbc4d43254d92cd3
  305  git log -p fdb434483a63896c58f7117fdbc4d43254d92cd3
  306  ls -l
  307  nano -w opendkim.conf
  308  ls -l
  309  nano -w mailer.conf 
  310  ls -l
  311  clear
  312  ls -l
  313  pwd
  314  pwd
  315  cd ..
  316  ls -l
  317  clear
  318  ls -l
  319  ls -l
  320  cd mail/
  321  ls -l
  322  clear
  323  ls -l
  324  nano -w opendkim.conf
  325  /usr/local/etc/rc.d/milter-opendkim start
  326  pw groupadd opendkim
  327  adduser
  328  cat /etc/passwd 
  329  pwd
  330  clear
  331  ls -l
  332  cd ..
  333  pwd
  334  cd opendkim/
  335  ls -l
  336  chmod 700 keys/
  337  chown -R opendkim:opendkim keys/
  338  ls -l
  339  uname -a
  340  /usr/local/etc/rc.d/milter-opendkim start
  341  tail /var/log/al
  342  tail /var/log/messages
  343  ps auxww|grep -i dkim
  344  ps auxww|grep -i open
  345  cd /va/rlog
  346  ls -l
  347  cd /var/log
  348  ls -lt
  297  git log opendkim.conf
  298  git diff fdb434483a63896c58f7117fdbc4d43254d92cd3
  299  git show fdb434483a63896c58f7117fdbc4d43254d92cd3
  300  ls -l
  301  git log .
  302  git diff .
  303  git diff fdb434483a63896c58f7117fdbc4d43254d92cd3:master
  304  git diff master:fdb434483a63896c58f7117fdbc4d43254d92cd3
  305  git log -p fdb434483a63896c58f7117fdbc4d43254d92cd3
  306  ls -l
  307  nano -w opendkim.conf
  308  ls -l
  309  nano -w mailer.conf 
  310  ls -l
  311  clear
  312  ls -l
  313  pwd
  314  pwd
  315  cd ..
  316  ls -l
  317  clear
  318  ls -l
  319  ls -l
  320  cd mail/
  321  ls -l
  322  clear
  323  ls -l
  324  nano -w opendkim.conf
  325  /usr/local/etc/rc.d/milter-opendkim start
  326  pw groupadd opendkim
  327  adduser
  328  cat /etc/passwd 
  329  pwd
  330  clear
  331  ls -l
  332  cd ..
  333  pwd
  334  cd opendkim/
  335  ls -l
  336  chmod 700 keys/
  337  chown -R opendkim:opendkim keys/
  338  ls -l
  339  uname -a
  340  /usr/local/etc/rc.d/milter-opendkim start
  341  tail /var/log/al
  342  tail /var/log/messages
  343  ps auxww|grep -i dkim
  344  ps auxww|grep -i open
  345  cd /va/rlog
  346  ls -l
  347  cd /var/log
  348  ls -lt
  349  /usr/local/sbin/opendkim -l -u opendkim -P /var/run/milteropendkim/pid -x /usr/local/etc/mail/opendkim.conf -v
  350  ps auxww|grep -i dkim
  351  /usr/local/sbin/opendkim -l -u opendkim -P /var/run/milteropendkim/pid -x /usr/local/etc/mail/opendkim.conf -vvvv
  352  chown opendkim:opendkim /var/run/opendkim
  353  mkdir /var/run/opendkim
  354  chown opendkim:opendkim /var/run/opendkim
  355  /usr/local/etc/rc.d/milter-opendkim start
  356  ps auxww|grep -i dkim
  357  cd /usr/local/etc/
  358  cd ke
  359  ls -l
  360  cd opendkim/keys/
  361  ls -l
  362  cd buildbot.net/
  363  ls -l
  364  cat mail.txt 
  365  cat mail.txt 
  366  pwd
  367  uname -a
  368  ls -l
  369  nano -w mail.txt 
  370  ls -l
  371  nano -w mail.private 
  372  uname -a
  373  pwd
  374  cd ..
  375  cd ..
  376  cd ..
  377  pwd
  378  git commit -m 'safe' .
  379  ls -l
  380  cd postfix/
  381  ls -l
  382  ls -l
  383  nano -w main.cf
  384  pwd
  385  uname -a
  386  nano -w main.cf
  387  git commit -m 'safe' .
  388  nano -w main.cf
  389  git commit -m 'safe' .
  390  /usr/local/etc/rc.d/postfix restart
  391  echo testing|mail amardtakhar@gmail.com
  392  tail /var/log/maillog
  393  cd /usr/local/etc/
  394  ls -l
  395  cd mail/
  396  ls -l
  397  cd ../postfix/
  398  postmap virtusertable
  399  postmap transport
  400  /usr/local/etc/rc.d/postfix restart
  401  echo testing4|mail amardtakhar@gmail.com
  402  tail -n 300 /var/log/postfix.log 
  403  pwd
  404  echo testing4|mail amardtakhar@gmail.com
  405  nano -w /etc/group 
  406  nano -w /etc/group 
  407  /usr/local/etc/rc.d/postfix restart
  408  echo testing4|mail amardtakhar@gmail.com
  409  echo testing-buildbot|mail tardyp@gmail.com
  410  pwd
  411  ls -l
  412  ls -l
  413  pwd
  414  cd ..
  415  cd opendkim/
  416  ls -l
  417  cat SigningTable 
  418  ls -l
  419  nano -w SigningTable 
  420  uname -a
  421  cd /var/log
  422  tail -f postfix.log 
  423  ls -lt
  424  pwd
  425  uname -a
  426  echo testing4 | mail sysadmin@rtems.org
  427  uname -a
  428  pwd
  429  uname -a
  430  opendkim-testkey -d rtems.org -s mail -vvv
  431  uname -a
```