### PR TITLE
limit number of indices in elastic

### DIFF
--- a/roles/elk/templates/logstash_events.conf
+++ b/roles/elk/templates/logstash_events.conf
@@ -6,6 +6,9 @@ input {
 }
 
 output {
-    elasticsearch { hosts => ["{{ internal_ip }}:{{ elastic_port }}"] }
+    elasticsearch {
+      hosts => ["{{ internal_ip }}:{{ elastic_port }}"]
+      index => "logstash-%{+YYYY}"
+    }
     stdout { codec => rubydebug }
 }


### PR DESCRIPTION
elastic do not like a high number of indices, as it loads all indices in memory from start
with low activity indexing like events, this makes no sense to create one index per day (default logstash)