### PR TITLE
bb-master: Don't use /dev/null as destination for get_url

### DIFF
--- a/roles/bb-master/tasks/main.yml
+++ b/roles/bb-master/tasks/main.yml
@@ -4,8 +4,12 @@
 - name: 'Check for running master'
   get_url:
     url: http://{{ web_host_name }}/
-    dest: /dev/null
+    dest: "{{ bb_user_home }}/.tmp-buildbot-master-check"
   register: master_ping
+  ignore_errors: True
+
+- name: 'Remove downloaded file'
+  shell: "rm -f {{ bb_user_home }}/.tmp-buildbot-master-check"
   ignore_errors: True
 
 - name: 'Check for busy master'


### PR DESCRIPTION
get_url does not treat /dev/null as a special file and tries to remove and rename on top of it.

This fixes failing ansible refresh in current production, at least when run from command line.