### PR TITLE
Update Ansible version and convert to using Python 3

### DIFF
--- a/bootstrap.yml
+++ b/bootstrap.yml
@@ -29,7 +29,7 @@
   # There's an overlap here with run-once script.  I (sa2ajj) could not think
   # of any "nicer" way though.
   - name: install ansible
-    raw: "pkg install --yes python2 {{ pkg_ansible_version }}"
+    raw: "pkg install --yes python3 {{ pkg_ansible_version }}"
 
   - name: prepare bootstrap script
     template:

--- a/group_vars/all
+++ b/group_vars/all
@@ -1,9 +1,9 @@
 # This file defines all kind of global parameters and defaults
 ---
-# Use non-fully qualified name of python2
-# On FreeBSD machines it's available as /usr/local/bin/python2, on most Linux
-# machines it's available as /usr/bin/python2
-ansible_python_interpreter: python2
+# Use non-fully qualified name of python3
+# On FreeBSD machines it's available as /usr/local/bin/python3, on most Linux
+# machines it's available as /usr/bin/python3
+ansible_python_interpreter: python3
 pkg_ansible_version: py27-ansible25
 
 # admin users have administrative access to all systems (but they know better

--- a/group_vars/all
+++ b/group_vars/all
@@ -4,7 +4,7 @@
 # On FreeBSD machines it's available as /usr/local/bin/python3, on most Linux
 # machines it's available as /usr/bin/python3
 ansible_python_interpreter: python3
-pkg_ansible_version: py27-ansible25
+pkg_ansible_version: py38-ansible27
 
 # admin users have administrative access to all systems (but they know better
 # than to change things by hand).  They will be added to the 'wheel' group.

--- a/roles/jail/tasks/main.yml
+++ b/roles/jail/tasks/main.yml
@@ -7,7 +7,7 @@
 
 - name: create jail
   tags: jail
-  command: "python2 /usr/local/bin/create_jail.py  {{ ezjail_default_flavour }} {{ name }} {{ hosts_ips[name] }} {{ internal_network }} {{ external_network}} {{ internet_visible }} '{{internal_if}}' '{{ external_if }}'"
+  command: "python3 /usr/local/bin/create_jail.py  {{ ezjail_default_flavour }} {{ name }} {{ hosts_ips[name] }} {{ internal_network }} {{ external_network}} {{ internet_visible }} '{{internal_if}}' '{{ external_if }}'"
   args:
     creates: "{{ ezjail_conf_dir }}/{{ name }}"
   register: jail_created

--- a/roles/virtualenv3/tasks/main.yml
+++ b/roles/virtualenv3/tasks/main.yml
@@ -19,7 +19,7 @@
     name: "{{ item }}"
     editable: false
     virtualenv: "{{ venv_home_dir }}/{{ venv_name }}"
-    virtualenv_command: "/usr/local/bin/python3.6 -m venv"
+    virtualenv_command: "/usr/local/bin/python3 -m venv"
   environment: "{{ proxy_env }}"
   with_items: "{{ venv_python_packages }}"
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist=lint,ansible-syntax
 skipsdist=true
-basepython = python2.7
+basepython = python3.8
 
 [testenv:lint]
 deps=

--- a/vagrant.yml
+++ b/vagrant.yml
@@ -16,7 +16,7 @@
         {% endfor %}
         {% endif %}
         export ASSUME_ALWAYS_YES=YES;\
-        pkg install {{ pkg_ansible_version }} python2 git sudo rsync virtualbox-ose-additions;\
+        pkg install {{ pkg_ansible_version }} python3 git sudo rsync virtualbox-ose-additions;\
         touch /root/.run-once
 - name: gather facts when ssh
   connection: ssh


### PR DESCRIPTION
I updated service2 and service 3 to FreeBSD 13.0-RELEASE. That means they can access up-to-date packages, including Python 3 packages. Convert Ansible and `python2` references to running under Python 3.