### PR TITLE
Update to Kibana 6 and Elasticsearch 6

### DIFF
--- a/roles/elk/meta/main.yml
+++ b/roles/elk/meta/main.yml
@@ -4,9 +4,9 @@ dependencies:
 
 - role: packages
   packages:
-    - elasticsearch5
+    - elasticsearch6
     - logstash
-    - kibana5
+    - kibana6
     - go  # for oauth2-proxy
 
 - role: user

--- a/roles/elk/templates/elasticsearch.yml
+++ b/roles/elk/templates/elasticsearch.yml
@@ -3,6 +3,5 @@
 
 network.host: {{ internal_ip }}
 http.port: {{ elastic_port }}
-path.conf: /usr/local/etc/elasticsearch
 path.data: /var/db/elasticsearch
 path.logs: /var/log/elasticsearch


### PR DESCRIPTION
The kibana5 and elasticsearch5 packages no longest exist. I picked the next available version for both, kibana6 and elasticsearch6. Some more work is still needed to get Elasticsearch working.