### PR TITLE
Upgrade bind to 9.16

### DIFF
--- a/roles/dns/tasks/main.yml
+++ b/roles/dns/tasks/main.yml
@@ -1,8 +1,8 @@
 # Configure Buildbot DNS service
 ---
-- name: install BIND v9.10
+- name: install BIND v9.16
   pkgng:
-    name: bind910
+    name: bind916
     state: present
   environment: "{{ proxy_env }}"
 


### PR DESCRIPTION
9.10 is no longer in FreeBSD repositories and thus playbook cannot proceed.