### PR TITLE
Reliability fixes

### DIFF
--- a/roles/base/tasks/ansible-pull.yml
+++ b/roles/base/tasks/ansible-pull.yml
@@ -75,7 +75,7 @@
   tags: ansible-pull
   cron:
     name: ansible-pull
-    job: "/home/{{ service_account }}/run-ansible-pull.sh"
+    job: "flock /home/{{ service_account }}/ansible-pull.lock /home/{{ service_account }}/run-ansible-pull.sh"
     user: "{{ service_account }}"
     minute: "{{ 60 | random(seed=ansible_fqdn) }}"
     state: "{{ 'absent' if no_ansible_pull|default('false')|bool else 'present' }}"

--- a/roles/base/templates/run-ansible-pull.sh.j2
+++ b/roles/base/templates/run-ansible-pull.sh.j2
@@ -21,17 +21,7 @@ while [[ $RETRY -lt $RETRIES ]]; do
     # run ansible-pull from the directory containing the repository (and, thus, the inventory file)
     cd /home/{{ service_account}}/repo
     set +e
-    # if coreutils is not yet installed, we should use ansible pull alone
-    ANSIBLE_PULL=ansible-pull
-    if command -v timeout >/dev/null
-    then
-        ANSIBLE_PULL="timeout -k 2m 40m $ANSIBLE_PULL"
-    elif command -v timelimit >/dev/null
-    then
-        # 2500s ~= 40min
-        ANSIBLE_PULL="timelimit -t 2500 -T 120 $ANSIBLE_PULL"
-    fi
-    $ANSIBLE_PULL  \
+    timeout -k 2m 40m ansible-pull  \
         -C master \
         -d /home/{{ service_account }}/repo/ \
         -m git \


### PR DESCRIPTION
Previously it was possible that multiple ansible-pull scripts were started concurrently (e.g. when one is failing due to timeout and retries repeatedly). Using flock avoids this issue.