### PR TITLE
Fix order of domains in certbot config

### DIFF
--- a/roles/nginx-proxy-letsencrypt/files/docker-compose.yml
+++ b/roles/nginx-proxy-letsencrypt/files/docker-compose.yml
@@ -32,8 +32,8 @@ services:
         --webroot
         --webroot-path /acme_webroot/
         -m povilas@radix.lt
-        -d docs.buildbot.net
         -d buildbot.net
+        -d docs.buildbot.net
         -d www.buildbot.net
     restart: "no"
     volumes:


### PR DESCRIPTION
This commit make certbot use buildbot.net instead of docs.buildbot.net as the name of identifier in its config and various paths.