### PR TITLE
Revert "Track infra repo state"

### DIFF
--- a/roles/base/tasks/ansible-pull.yml
+++ b/roles/base/tasks/ansible-pull.yml
@@ -55,7 +55,6 @@
     dest: "/home/{{ service_account }}/repo"
     version: master
     accept_hostkey: yes
-  register: infra_repo_state
   environment: "{{ proxy_env }}"
 
 - name: install ansible-pull cronscript

--- a/roles/bb-master-docker/tasks/main.yml
+++ b/roles/bb-master-docker/tasks/main.yml
@@ -40,9 +40,9 @@
 
   - name: Print current state
     ansible.builtin.debug:
-      msg: "Master building status: {{ master_building.status }} infra_repo_state: {{ infra_repo_state }} bb_repo_state: {{ bb_repo_state }} mbb_repo_state: {{ mbb_repo_state }}"
+      msg: "Master building status: {{ master_building.status }} bb_repo_state: {{ bb_repo_state }} mbb_repo_state: {{ mbb_repo_state }}"
 
-  - when: master_building.status != 200 or infra_repo_state is changed or bb_repo_state is changed or mbb_repo_state is changed
+  - when: master_building.status != 200 or bb_repo_state is changed or mbb_repo_state is changed
     block:
 
     - name: Create directories


### PR DESCRIPTION
Reverts buildbot/buildbot-infra#295

Turns out it's impossible to track infra repo state in git action because it's pulled by ansible pull already.