### PR TITLE
nginx-proxy-letsencrypt: Fix nginx reload

### DIFF
--- a/roles/nginx-proxy-letsencrypt/files/refresh_certs.sh
+++ b/roles/nginx-proxy-letsencrypt/files/refresh_certs.sh
@@ -3,4 +3,4 @@
 cd "$(dirname "${BASH_SOURCE[0]}")"
 
 docker-compose up certbot
-docker-compose exec nginx-proxy nginx -s reload
+docker-compose exec -T nginx-proxy nginx -s reload


### PR DESCRIPTION
docker-compose exec attempts to allocate tty by default. This will break in non-interactive shell like what is used to run cronjobs.